### PR TITLE
Remove BootstrapTokens logic

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -89,11 +89,6 @@ func (v APIEndpoint) String() string {
 type InitConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
-	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
-	// +optional
-	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
-
 	// +optional
 	LocalAPIEndpoint APIEndpoint `json:"localAPIEndpoint,omitempty"`
 }

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -104,13 +104,6 @@ func (in *ClusterConfiguration) DeepCopyObject() runtime.Object {
 func (in *InitConfiguration) DeepCopyInto(out *InitConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.BootstrapTokens != nil {
-		in, out := &in.BootstrapTokens, &out.BootstrapTokens
-		*out = make([]BootstrapToken, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	out.LocalAPIEndpoint = in.LocalAPIEndpoint
 }
 
@@ -226,7 +219,7 @@ func (in *MicroK8sConfigSpec) DeepCopyInto(out *MicroK8sConfigSpec) {
 	if in.InitConfiguration != nil {
 		in, out := &in.InitConfiguration, &out.InitConfiguration
 		*out = new(InitConfiguration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.JoinConfiguration != nil {
 		in, out := &in.JoinConfiguration, &out.JoinConfiguration

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -62,50 +62,6 @@ spec:
                       schemas to the latest internal value, and may reject unrecognized
                       values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
-                  bootstrapTokens:
-                    description: BootstrapTokens is respected at `kubeadm init` time
-                      and describes a set of Bootstrap Tokens to create. This information
-                      IS NOT uploaded to the kubeadm cluster configmap, partly because
-                      of its sensitive nature
-                    items:
-                      properties:
-                        description:
-                          description: Description sets a human-friendly message why
-                            this token exists and what it's used for, so other administrators
-                            can know its purpose.
-                          type: string
-                        expires:
-                          description: Expires specifies the timestamp when this token
-                            expires. Defaults to being set dynamically at runtime
-                            based on the TTL. Expires and TTL are mutually exclusive.
-                          format: date-time
-                          type: string
-                        groups:
-                          description: Groups specifies the extra groups that this
-                            token will authenticate as when/if used for authentication
-                          items:
-                            type: string
-                          type: array
-                        token:
-                          description: Token is used for establishing bidirectional
-                            trust between nodes and control-planes. Used for joining
-                            nodes in the cluster.
-                          type: string
-                        ttl:
-                          description: TTL defines the time to live for this token.
-                            Defaults to 24h. Expires and TTL are mutually exclusive.
-                          type: string
-                        usages:
-                          description: Usages describes the ways in which this token
-                            can be used. Can by default be used for establishing bidirectional
-                            trust, but that can be changed here.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - token
-                      type: object
-                    type: array
                   kind:
                     description: 'Kind is a string value representing the REST resource
                       this object represents. Servers may infer this from the endpoint

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -71,54 +71,6 @@ spec:
                               convert recognized schemas to the latest internal value,
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
-                          bootstrapTokens:
-                            description: BootstrapTokens is respected at `kubeadm
-                              init` time and describes a set of Bootstrap Tokens to
-                              create. This information IS NOT uploaded to the kubeadm
-                              cluster configmap, partly because of its sensitive nature
-                            items:
-                              properties:
-                                description:
-                                  description: Description sets a human-friendly message
-                                    why this token exists and what it's used for,
-                                    so other administrators can know its purpose.
-                                  type: string
-                                expires:
-                                  description: Expires specifies the timestamp when
-                                    this token expires. Defaults to being set dynamically
-                                    at runtime based on the TTL. Expires and TTL are
-                                    mutually exclusive.
-                                  format: date-time
-                                  type: string
-                                groups:
-                                  description: Groups specifies the extra groups that
-                                    this token will authenticate as when/if used for
-                                    authentication
-                                  items:
-                                    type: string
-                                  type: array
-                                token:
-                                  description: Token is used for establishing bidirectional
-                                    trust between nodes and control-planes. Used for
-                                    joining nodes in the cluster.
-                                  type: string
-                                ttl:
-                                  description: TTL defines the time to live for this
-                                    token. Defaults to 24h. Expires and TTL are mutually
-                                    exclusive.
-                                  type: string
-                                usages:
-                                  description: Usages describes the ways in which
-                                    this token can be used. Can by default be used
-                                    for establishing bidirectional trust, but that
-                                    can be changed here.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - token
-                              type: object
-                            type: array
                           kind:
                             description: 'Kind is a string value representing the
                               REST resource this object represents. Servers may infer

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -183,19 +183,7 @@ func (r *MicroK8sConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	// Status is ready means a config has been generated.
 	case config.Status.Ready:
-		// if config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil {
-		// 	if !configOwner.IsInfrastructureReady() {
-		// 		// If the BootstrapToken has been generated for a join and the infrastructure is not ready.
-		// 		// This indicates the token in the join config has not been consumed and it may need a refresh.
-		// 		//	return r.refreshBootstrapToken(ctx, config, cluster)
-		// 	}
-		// 	if configOwner.IsMachinePool() {
-		// 		// If the BootstrapToken has been generated and infrastructure is ready but the configOwner is a MachinePool,
-		// 		// we rotate the token to keep it fresh for future scale ups.
-		// 		//		return r.rotateMachinePoolBootstrapToken(ctx, config, cluster, scope)
-		// 	}
-		// }
-		// In any other case just return as the config is already generated and need not be generated again.
+		// Just return as the config is already generated and need not be generated again.
 		return ctrl.Result{}, nil
 	}
 
@@ -237,12 +225,6 @@ func (r *MicroK8sConfigReconciler) handleClusterNotInitialized(ctx context.Conte
 
 	// if it's NOT a control plane machine, requeue
 	if !scope.ConfigOwner.IsControlPlaneMachine() {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
-	// if the machine has not ClusterConfiguration and InitConfiguration, requeue
-	if scope.Config.Spec.InitConfiguration == nil && scope.Config.Spec.ClusterConfiguration == nil {
-		scope.Info("Control plane is not ready, requeueing joining control planes until ready.")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 

--- a/examples/aws-capi-quickstart.yaml
+++ b/examples/aws-capi-quickstart.yaml
@@ -1,128 +1,104 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: capi-quickstart
+  name: capi-aws-19072022-4
   namespace: default
 spec:
-#  clusterNetwork:
-#    apiServerPort: 6443
+  # clusterNetwork:
+  #   pods:
+  #     cidrBlocks: ["192.168.0.0/16"] # CIDR block used by Calico.
+  #   serviceDomain: "cluster.local"
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: MicroK8sControlPlane
-    name: capi-quickstart-control-plane
+    name: capi-aws-19072022-4-control-plane
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
-    name: capi-quickstart
+    name: capi-aws-19072022-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
-  name: capi-quickstart
+  name: capi-aws-19072022-4
   namespace: default
 spec:
   region: us-east-1
-  sshKeyName: ad-hoc
+  sshKeyName: default
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: MicroK8sControlPlane
 metadata:
-  name: capi-quickstart-control-plane
+  name: capi-aws-19072022-4-control-plane
   namespace: default
 spec:
   controlPlaneConfig:
     controlplane:
       joinConfiguration:
         connectionToken: "dG91Y2ggL3Zhci90bXAvZm9v"
-        
- 
-  #  clusterConfiguration:
-  #    apiServer:
-  #      extraArgs:
-  #        cloud-provider: aws
-  #    controllerManager:
-  #      extraArgs:
-  #        cloud-provider: aws
-  #  initConfiguration:
-  #     bootstrapTokens:
-  #     - token: "MYTOKEN"
-  #    nodeRegistration:
-  #      kubeletExtraArgs:
-  #        cloud-provider: aws
-  #      name: '{{ ds.meta_data.local_hostname }}'
-  #  joinConfiguration:
-  #    nodeRegistration:
-  #      kubeletExtraArgs:
-  #        cloud-provider: aws
-  #      name: '{{ ds.meta_data.local_hostname }}'
   machineTemplate:
     infrastructureTemplate:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AWSMachineTemplate
-      name: capi-quickstart-control-plane
-  replicas: 3
+      name: capi-aws-19072022-4-control-plane
+  replicas: 4
   version: v1.23.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
-  name: capi-quickstart-control-plane
+  name: capi-aws-19072022-4-control-plane
   namespace: default
 spec:
   template:
     spec:
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: t3.large
-      sshKeyName: ad-hoc
+      sshKeyName: default
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: capi-quickstart-md-0
+  name: capi-aws-19072022-4-md-0
   namespace: default
 spec:
-  clusterName: capi-quickstart
+  clusterName: capi-aws-19072022-4
   replicas: 0
   selector:
     matchLabels: null
   template:
     spec:
+      clusterName: capi-aws-19072022-4
+      version: v1.23.0     
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: MicroK8sConfigTemplate
-          name: capi-quickstart-md-0
-      clusterName: capi-quickstart
+          name: capi-aws-19072022-4-md-0
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
-        name: capi-quickstart-md-0
-      version: v1.23.0
+        name: capi-aws-19072022-4-md-0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
-  name: capi-quickstart-md-0
+  name: capi-aws-19072022-4-md-0
   namespace: default
 spec:
   template:
     spec:
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: t3.large
-      sshKeyName: ad-hoc
+      sshKeyName: default
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: MicroK8sConfigTemplate
 metadata:
-  name: capi-quickstart-md-0
+  name: capi-aws-19072022-4-md-0
   namespace: default
 spec:
   template:
     spec:
       joinConfiguration:
         connectionToken: "dG91Y2ggL3Zhci90bXAvZm9v"
-      #initConfiguration:
-        #nodeRegistration:
-        #  kubeletExtraArgs:
-        #    cloud-provider: aws
-        #  name: '{{ ds.meta_data.local_hostname }}'

--- a/examples/openstack-capi-quickstart.yaml
+++ b/examples/openstack-capi-quickstart.yaml
@@ -44,8 +44,6 @@ spec:
       joinConfiguration:
         connectionToken: "dG91Y2ggL3Zhci90bXAvZm9v"
       initConfiguration:
-        bootstrapTokens:
-        - token: "ALSOMYTOKEN"
   machineTemplate:
     infrastructureTemplate:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
@@ -119,5 +117,3 @@ spec:
       joinConfiguration:
         connectionToken: "dG91Y2ggL3Zhci90bXAvZm9v"
       initConfiguration:
-        bootstrapTokens:
-        - token: "MYTOKEN"


### PR DESCRIPTION
This PR removes the BootstrapToken struct from the config specs and the corresponding logic from the controller.

Verified that the cluster is provisioned correctly:
```bash
$ kubectl get clusters
NAME                  PHASE         AGE   VERSION
capi-aws-19072022-4   Provisioned   30m   

$ kubectl get machines
NAME                                      CLUSTER               NODENAME         PROVIDERID                              PHASE     AGE   VERSION
capi-aws-19072022-4-control-plane-n5pvb   capi-aws-19072022-4   ip-10-0-182-80   aws:///us-east-1b/i-0576e23980facc680   Running   26m   v1.23.0
```