### PR TITLE
Add Makefile target lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,9 @@ jobs:
       - name: go vet
         run: make vet
 
+      - name: golangci-lint
+        run: make lint
+
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ docker-build: test ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+.PHONY: lint
+lint: golangci-lint ## Lint the codebase
+	$(GOLANGCI_LINT) run -v
+
 ##@ Deployment
 
 ifndef ignore-not-found
@@ -107,6 +111,12 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+.PHONY: golangci-lint
+golangci-lint: ## Download golangci-lint locally if necessary.
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0)
+
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -705,19 +705,25 @@ func (r *MicroK8sConfigReconciler) generateCA() (cert *string, key *string, err 
 
 	// pem encode
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	err = pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
+	err = pem.Encode(caPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 
-	certstr := string(caPEM.Bytes())
-	keystr := string(caPrivKeyPEM.Bytes())
+	certstr := caPEM.String()
+	keystr := caPrivKeyPEM.String()
 	return &certstr, &keystr, nil
 }
 


### PR DESCRIPTION
Hi :wave:

This pr adds a `make lint` Makefile taget that
* downloads golangci-lint 
* runs golangci-lint 

Since I've also fixed the findings that golangci-lint found. Note this is not the latest and greatest golangci-lint version but it's what worked with go1.17. I haven't added it to any workflow but maybe it's something that should be in the build. 