### PR TITLE
Enable additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,33 @@
+linters:
+  disable-all: true
+  enable:
+    # Enable all default checks
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    # Enable additional linters
+    - asciicheck
+    - bidichk
+    - contextcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gofmt
+    - makezero
+    - misspell
+    - nilerr
+    - prealloc
+    - revive
+    - unparam
+    - whitespace
+
+linters-settings:
+  revive:
+    rules:
+      - name: blank-imports
+        disabled: true

--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -84,11 +84,11 @@ type InitConfiguration struct {
 
 	// The optional https proxy configuration
 	// +optional
-	HttpsProxy *string `json:"httpsProxy,omitempty"`
+	HTTPSProxy *string `json:"httpsProxy,omitempty"`
 
 	// The optional http proxy configuration
 	// +optional
-	HttpProxy *string `json:"httpProxy,omitempty"`
+	HTTPProxy *string `json:"httpProxy,omitempty"`
 
 	// The optional no proxy configuration
 	// +optional

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -70,13 +70,13 @@ func (in *InitConfiguration) DeepCopyInto(out *InitConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	out.LocalAPIEndpoint = in.LocalAPIEndpoint
-	if in.HttpsProxy != nil {
-		in, out := &in.HttpsProxy, &out.HttpsProxy
+	if in.HTTPSProxy != nil {
+		in, out := &in.HTTPSProxy, &out.HTTPSProxy
 		*out = new(string)
 		**out = **in
 	}
-	if in.HttpProxy != nil {
-		in, out := &in.HttpProxy, &out.HttpProxy
+	if in.HTTPProxy != nil {
+		in, out := &in.HTTPProxy, &out.HTTPProxy
 		*out = new(string)
 		**out = **in
 	}

--- a/controllers/cloudinit/cloudinit_test.go
+++ b/controllers/cloudinit/cloudinit_test.go
@@ -52,7 +52,7 @@ func TestNewInitControlPlaneCommands(t *testing.T) {
 	http := "http://proxy"
 	cpinputproxy := &ControlPlaneInput{
 		Version:   "v1.23.3",
-		HttpProxy: &http,
+		HTTPProxy: &http,
 	}
 
 	out, err = NewInitControlPlane(cpinputproxy)
@@ -66,7 +66,6 @@ func TestNewInitControlPlaneCommands(t *testing.T) {
 	for _, f := range expectedCommands {
 		g.Expect(a).To(ContainSubstring(f))
 	}
-
 }
 
 func TestNewJoinControlPlaneCommands(t *testing.T) {

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -85,8 +85,8 @@ type ControlPlaneInput struct {
 	Version                  string
 	PortOfClusterAgent       string
 	PortOfDqlite             string
-	HttpsProxy               *string
-	HttpProxy                *string
+	HTTPSProxy               *string
+	HTTPProxy                *string
 	NoProxy                  *string
 	Addons                   []string
 }
@@ -116,21 +116,21 @@ func NewInitControlPlane(input *ControlPlaneInput) ([]byte, error) {
 		input.Addons = append(input.Addons, "dns")
 	}
 
-	var addons_str string
+	var addonsStr string
 	for _, addon := range input.Addons {
-		addons_str += fmt.Sprintf(" '%s' ", addon)
+		addonsStr += fmt.Sprintf(" '%s' ", addon)
 	}
-	cloudinit_str := strings.Replace(controlPlaneCloudInit, "{{.Addons}}", addons_str, -1)
+	cloudinitStr := strings.Replace(controlPlaneCloudInit, "{{.Addons}}", addonsStr, -1)
 
-	proxyCommands := generateProxyCommands(input.HttpsProxy, input.HttpProxy, input.NoProxy)
-	cloudinit_str = strings.Replace(cloudinit_str, "{{.ProxySection}}", proxyCommands, -1)
+	proxyCommands := generateProxyCommands(input.HTTPSProxy, input.HTTPProxy, input.NoProxy)
+	cloudinitStr = strings.Replace(cloudinitStr, "{{.ProxySection}}", proxyCommands, -1)
 
 	addr := net.ParseIP(input.ControlPlaneEndpoint)
 	if addr != nil {
 		input.ControlPlaneEndpointType = "IP"
 	}
 
-	userData, err := generate("InitControlplane", cloudinit_str, input)
+	userData, err := generate("InitControlplane", cloudinitStr, input)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -67,8 +67,8 @@ type ControlPlaneJoinInput struct {
 	PortOfNodeToJoin         string
 	PortOfDqlite             string
 	Version                  string
-	HttpsProxy               *string
-	HttpProxy                *string
+	HTTPSProxy               *string
+	HTTPProxy                *string
 	NoProxy                  *string
 }
 
@@ -87,10 +87,10 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) ([]byte, error) {
 		input.ControlPlaneEndpointType = "IP"
 	}
 
-	proxyCommands := generateProxyCommands(input.HttpsProxy, input.HttpProxy, input.NoProxy)
-	cloudinit_str := strings.Replace(controlPlaneJoinCloudInit, "{{.ProxySection}}", proxyCommands, -1)
+	proxyCommands := generateProxyCommands(input.HTTPSProxy, input.HTTPProxy, input.NoProxy)
+	cloudinitStr := strings.Replace(controlPlaneJoinCloudInit, "{{.ProxySection}}", proxyCommands, -1)
 
-	userData, err := generate("JoinControlplane", cloudinit_str, input)
+	userData, err := generate("JoinControlplane", cloudinitStr, input)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate user data for machine joining control plane")
 	}

--- a/controllers/cloudinit/utils.go
+++ b/controllers/cloudinit/utils.go
@@ -37,8 +37,8 @@ func templateYAMLIndent(i int, input string) string {
 	return strings.Repeat(" ", i) + strings.Join(split, ident)
 }
 
-func extractVersionParts(version_str string) (int, int, error) {
-	v, err := version.NewVersion(version_str)
+func extractVersionParts(versionStr string) (int, int, error) {
+	v, err := version.NewVersion(versionStr)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -56,8 +56,8 @@ type WorkerJoinInput struct {
 	PortOfNodeToJoin     string
 	Version              string
 	ControlPlaneEndpoint string
-	HttpsProxy           *string
-	HttpProxy            *string
+	HTTPSProxy           *string
+	HTTPProxy            *string
 	NoProxy              *string
 }
 
@@ -70,10 +70,10 @@ func NewJoinWorker(input *WorkerJoinInput) ([]byte, error) {
 	}
 	input.Version = generateSnapChannelArgument(major, minor)
 
-	proxyCommands := generateProxyCommands(input.HttpsProxy, input.HttpProxy, input.NoProxy)
-	cloudinit_str := strings.Replace(workerJoinCloudInit, "{{.ProxySection}}", proxyCommands, -1)
+	proxyCommands := generateProxyCommands(input.HTTPSProxy, input.HTTPProxy, input.NoProxy)
+	cloudinitStr := strings.Replace(workerJoinCloudInit, "{{.ProxySection}}", proxyCommands, -1)
 
-	userData, err := generate("JoinWorker", cloudinit_str, input)
+	userData, err := generate("JoinWorker", cloudinitStr, input)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate user data for machine joining as worker")
 	}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,6 @@ var (
 )
 
 func init() {
-
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	_ = expv1.AddToScheme(scheme)


### PR DESCRIPTION
golangci-lint has 7 linters enabled by default: 

```
    - errcheck
    - gosimple
    - govet
    - ineffassign
    - staticcheck
    - typecheck
    - unused
```

This pr adds some additional linters that might be good to have and fixes the findings. 

```
   - asciicheck
    - bidichk
    - contextcheck
    - errchkjson
    - errorlint
    - exhaustive
    - exportloopref
    - gofmt
    - makezero
    - misspell
    - nilerr
    - prealloc
    - revive
    - unparam
    - whitespace
```

source: https://golangci-lint.run/usage/linters
