### PR TITLE
Add cluster templates for AWS, OpenStack and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ providers:
     type: "ControlPlaneProvider"
 ```
 
-You will now be able now to initialize clusterctl with the MicroK8s providers: 
+You will now be able now to initialize clusterctl with the MicroK8s providers:
 
 ```
 clusterctl init --bootstrap microk8s --control-plane microk8s -i <infra-provider-of-choice>
@@ -49,51 +49,76 @@ Alternatively, you can build the providers manually as described in the followin
   * Install the cluster provider of your choice. Have a look at the [cluster API book](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers) for your options at this step. You should deploy only the infrastructure controller leaving the bootstrap and control plane ones empty. For example assuming we want to provision a MicroK8s cluster on AWS:
 ```
 clusterctl init --infrastructure aws --bootstrap "-" --control-plane "-"
-``` 
+```
 
   * Clone the two cluster API MicroK8s specific repositories and start the controllers on two separate terminals:
 ```
-cd $GOPATH/src/github.com/canonical/cluster-api-bootstrap-provider-microk8s/ 
+cd $GOPATH/src/github.com/canonical/cluster-api-bootstrap-provider-microk8s/
 make install
 make run
-``` 
+```
 And:
 ```
-cd $GOPATH/src/github.com/canonical/cluster-api-control-plane-provider-microk8s/ 
+cd $GOPATH/src/github.com/canonical/cluster-api-control-plane-provider-microk8s/
 make install
 make run
-``` 
+```
 
 ### Usage
 
-Aas soon as the bootstrap and control-plane controllers are up and running you can apply the cluster manifests describing the desired specs of the cluster you want to provision. Each machine is associated with a MicroK8sConfig through which you can set the cluster's properties. Please review  the available options in [the respective definitions file](./apis/v1beta1/microk8sconfig_types.go). You may also find useful the example manifests found under the [examples](./examples/) directory. Note that the configuration structure followed is similar to the the one of kubeadm, in the MicroK8sConfig you will find a CLusterConfiguration and an InitConfiguration sections. When targeting a specific infrastructure you should be aware of which ports are used by MicroK8s and allow them in the network security groups on your deployment.
+As soon as the bootstrap and control-plane controllers are up and running you can apply the cluster manifests describing the desired specs of the cluster you want to provision. Each machine is associated with a MicroK8sConfig through which you can set the cluster's properties. Please review  the available options in [the respective definitions file](./apis/v1beta1/microk8sconfig_types.go). You may also find useful the example manifests found under the [examples](./examples/) directory. Note that the configuration structure followed is similar to the the one of kubeadm, in the MicroK8sConfig you will find a CLusterConfiguration and an InitConfiguration sections. When targeting a specific infrastructure you should be aware of which ports are used by MicroK8s and allow them in the network security groups on your deployment.
 
-Deployment manifests we use to validate every release:
+Two workload cluster templates are available under the [templates](./templates/) folder, which are actively used to validate releases:
+- [AWS](./templates/cluster-template-aws.yaml), using the [AWS Infrastructure Provider](https://github.com/kubernetes-sigs/cluster-api-provider-aws)
+- [OpenStack](./templates/cluster-template-openstack.yaml), using the [OpenStack Infrastructure Provider](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
 
-  - [openstack](./examples/openstack-capi-quickstart.yaml)
-  - [aws](./examples/aws-capi-quickstart.yaml)
+Before generating a cluster, ensure that you have followed the instructions to set up the infrastructure provider that you will use.
 
-Some time after you apply the cluster manifests with for example:
+#### AWS
 
+> *NOTE*: Ensure that you have properly deployed the AWS infrastructure provider prior to executing the commands below. See [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
+
+Generate a cluster template with:
+
+```bash
+# review list of variables needed for the cluster template
+clusterctl generate cluster microk8s-aws --from ./templates/cluster-template-aws.yaml --list-variables
+
+# set environment variables (edit the file as needed before sourcing it)
+source ./templates/cluster-template-aws.rc
+
+# generate cluster
+clusterctl generate cluster microk8s-aws --from ./templates/cluster-template-aws.yaml > cluster-aws.yaml
 ```
-microk8s kubectl apply -f ./examples/aws-capi-quickstart.yaml
-```
-... you will see the machines reporting ready:
 
-```
-$ microk8s kubectl get machines -A
-NAMESPACE   NAME                                  CLUSTER          NODENAME                             PROVIDERID                                          PHASE     AGE    VERSION
-default     capi-aws-control-plane-wd94k          capi-aws         ip-10-0-95-69                        aws:///us-east-1a/i-0051fa0d99ae18e43               Running   10m   v1.23.0
-default     capi-aws-md-0-766784ddc4-75m6q        capi-aws         ip-10-0-120-139                      aws:///us-east-1a/i-0eb890a181c9b8215               Running   14m   v1.23.0
-default     capi-aws-control-plane-nkx2b          capi-aws         ip-10-0-218-228                      aws:///us-east-1c/i-0a28bd5ac4ee1ce5d               Running   10m   v1.23.0
-default     capi-aws-control-plane-f4tp2          capi-aws         ip-10-0-100-255                      aws:///us-east-1a/i-0280ea368cd050dd2               Running   10m   v1.23.0
-default     capi-aws-md-0-766784ddc4-n8csl        capi-aws         ip-10-0-69-166                       aws:///us-east-1a/i-01cbbd4c07df2eb8c               Running   14m   v1.23.0
+Then deploy the cluster with:
+
+```bash
+microk8s kubectl apply -f cluster-aws.yaml
 ```
 
-With clusterctl you can get the cluster's kubeconfig file:
+The MicroK8s cluster will be deployed shortly afterwards. You can see the provisioned machines with:
+
+```bash
+# microk8s kubectl get machines
+NAME                                 CLUSTER        NODENAME          PROVIDERID                              PHASE     AGE   VERSION
+microk8s-aws-control-plane-wd94k     microk8s-aws   ip-10-0-95-69     aws:///us-east-1a/i-0051fa0d99ae18e43   Running   10m   v1.23.0
+microk8s-aws-md-0-766784ddc4-75m6q   microk8s-aws   ip-10-0-120-139   aws:///us-east-1a/i-0eb890a181c9b8215   Running   14m   v1.23.0
+microk8s-aws-control-plane-nkx2b     microk8s-aws   ip-10-0-218-228   aws:///us-east-1c/i-0a28bd5ac4ee1ce5d   Running   10m   v1.23.0
+microk8s-aws-control-plane-f4tp2     microk8s-aws   ip-10-0-100-255   aws:///us-east-1a/i-0280ea368cd050dd2   Running   10m   v1.23.0
+microk8s-aws-md-0-766784ddc4-n8csl   microk8s-aws   ip-10-0-69-166    aws:///us-east-1a/i-01cbbd4c07df2eb8c   Running   14m   v1.23.0
 ```
-$ clusterctl get kubeconfig capi-aws > ~/tmp/w.config
-$ KUBECONFIG=/home/jackal/tmp/w.config kubectl get no
+
+With clusterctl you can then retrieve the kubeconfig file for the workload cluster:
+
+```bash
+clusterctl get kubeconfig microk8s-aws > kubeconfig
+```
+
+And then use it to access the cluster:
+
+```bash
+# KUBECONFIG=./kubeconfig kubectl get node
 NAME              STATUS   ROLES    AGE     VERSION
 ip-10-0-95-69     Ready    <none>   9m11s   v1.23.9-2+88a2c6a14e7008
 ip-10-0-120-139   Ready    <none>   2m45s   v1.23.9-2+88a2c6a14e7008
@@ -102,22 +127,47 @@ ip-10-0-100-255   Ready    <none>   108s    v1.23.9-2+88a2c6a14e7008
 ip-10-0-218-228   Ready    <none>   110s    v1.23.9-2+88a2c6a14e7008
 ```
 
-To discard the cluster delete the cluster manifest:
+To discard the cluster, delete the `microk8s-aws` cluster.
 
+```bash
+microk8s kubectl delete cluster microk8s-aws
 ```
-microk8s.kubectl delete -f ./examples/aws-capi-quickstart.yaml
-```
+
+> *NOTE*: This command might take a while, because it ensures that the providers properly clean up any resources (Virtual Machines, Load Balancers, etc) that were provisioned while setting up the cluster
 
 ... and also the secrets created:
 
-```
-$ microk8s.kubectl delete secret capi-aws-jointoken  capi-aws-ca  capi-aws-kubeconfig
-secret "capi-aws-jointoken" deleted
-secret "capi-aws-ca" deleted
-secret "capi-aws-kubeconfig" deleted
+```bash
+# microk8s kubectl delete secret microk8s-aws-jointoken  microk8s-aws-ca  microk8s-aws-kubeconfig
+secret "microk8s-aws-jointoken" deleted
+secret "microk8s-aws-ca" deleted
+secret "microk8s-aws-kubeconfig" deleted
 ```
 
-**Note:** if you want to provide your own CA and/or the join token used to form a cluster you will need to create the respective secrets (`<cluster-name>-ca` and `<cluster-name>-jointoken`) before applying the cluster manifests. 
+**Note:** if you want to provide your own CA and/or the join token used to form a cluster you will need to create the respective secrets (`<cluster-name>-ca` and `<cluster-name>-jointoken`) before applying the cluster manifests.
+
+#### OpenStack
+
+> *NOTE*: Ensure that you have properly deployed the OpenStack infrastructure provider prior to executing the commands below. See [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
+
+Generate a cluster template with:
+
+```bash
+# review list of variables needed for the cluster template
+clusterctl generate cluster microk8s-openstack --from ./templates/cluster-template-openstack.yaml --list-variables
+
+# set environment variables (edit the file as needed before sourcing it)
+source ./templates/cluster-template-openstack.rc
+
+# generate cluster
+clusterctl generate cluster microk8s-openstack --from ./templates/cluster-template-openstack.yaml > cluster-openstack.yaml
+```
+
+Then deploy the cluster with:
+
+```bash
+microk8s kubectl apply -f cluster-openstack.yaml
+```
 
 ## Development
 
@@ -125,22 +175,20 @@ The two MicroK8s CAPI providers, the bootstrap and control plane, serve distinct
 
 #### The bootstrap provider
 
-  Produce the cloudinit file for all node types: the first cluster node, the control plane nodes and the worker nodes. The cloudinit file is encoded as a secret linked to each machine. This way the infrastructure provider can proceed with the instantiation of the machine.
-  
-  The most important of the three cloudinit files is the one of the cluster's first node. Its assembly requires the bootstrap provider to have already a join token and a CA. The join token is the one used by other nodes to join the cluster and the CA is used by all cluster nodes and to also produce the admin's kubeconfig file.
+  * Produce the cloudinit file for all node types: the first cluster node, the control plane nodes and the worker nodes. The cloudinit file is encoded as a secret linked to each machine. This way the infrastructure provider can proceed with the instantiation of the machine.
+
+  * The most important of the three cloudinit files is the one of the cluster's first node. Its assembly requires the bootstrap provider to have already a join token and a CA. The join token is the one used by other nodes to join the cluster and the CA is used by all cluster nodes and to also produce the admin's kubeconfig file.
 
 #### The control plane provider
 
   * Ensure the Provider ID is set on each node. MicroK8s out of the box does not set the provider ID on any of the nodes. The control plane provider makes sure the ID is set as soon as a node is ready. The infrastructure provider sets the provider ID on each provisioned machine, the control plane provider updates the cluster nodes after matching each one of them to the respective machine. The machine to node matching is done based on their IPs.
 
   * Produce the kubeconfig file of the provisioned cluster. To produce the kubeconfig file the controller needs to know the control plane endpoint and the CA used. The control plane endpoint is usually provided by the load balancer of the infrastructure used. The CA is generated by the bootstrap provider when the first node of the infrastructure is instantiated. The authentication method used in the kubeconfig is x509. The CA is used to sign a certificate that has "admin" as its common name, therefore mapped to the admin user.
-    
 
 #### Deployment of components
 
 <img src="./images/deployment_diagram.svg">
 
-#### Interactions among controllers 
+#### Interactions among controllers
 
 <img src="./images/sequence_diagram.svg">
-

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -1,0 +1,14 @@
+# Kubernetes cluster configuration
+export KUBERNETES_VERSION=1.24.0
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+
+# AWS region
+export AWS_REGION="eu-west-1"
+
+# AWS machine configuration
+export AWS_CREATE_BASTION=true
+export AWS_PUBLIC_IP=false
+export AWS_CONTROL_PLANE_MACHINE_FLAVOR=t3.large
+export AWS_NODE_MACHINE_FLAVOR=t3.large
+export AWS_SSH_KEY_NAME=my-ssh-key

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -1,0 +1,103 @@
+# Based on https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v1.5.0/cluster-template.yaml
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AWSCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: MicroK8sControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: ${CLUSTER_NAME}-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  region: ${AWS_REGION}
+  sshKeyName: ${AWS_SSH_KEY_NAME}
+  bastion:
+    enabled: ${AWS_CREATE_BASTION:=false}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: MicroK8sControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  controlPlaneConfig:
+    initConfiguration:
+      joinTokenTTLInSecs: 9000
+      addons:
+        - dns
+        - ingress
+    clusterConfiguration:
+      portCompatibilityRemap: true
+  machineTemplate:
+    infrastructureTemplate:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AWSMachineTemplate
+      name: "${CLUSTER_NAME}-control-plane"
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+  version: "v${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: ${AWS_CONTROL_PLANE_INSTANCE_TYPE:=t3.large}
+      publicIP: ${AWS_PUBLIC_IP:=false}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT:=1}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: MicroK8sConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta
+        kind: AWSMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: ${AWS_NODE_INSTANCE_TYPE:=t3.large}
+      publicIP: ${AWS_PUBLIC_IP:=false}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: MicroK8sConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      clusterConfiguration:
+        portCompatibilityRemap: true

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -1,0 +1,35 @@
+# Kubernetes cluster configuration
+export KUBERNETES_VERSION=1.24.0
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+
+# OpenStack credentials configuration
+# If unsure, consult "Horizon" > "API Access" > "Download OpenStack RC File" > "OpenStack clouds.yaml File"
+export OPENSTACK_CLOUD=openstack
+export OPENSTACK_CLOUD_CACERT_B64="Cg=="
+export OPENSTACK_CLOUD_YAML_B64="$(echo '
+clouds:
+  openstack:
+    auth:
+      auth_url: "<OS_AUTH_URL>"
+      username: "<OS_USERNAME>"
+      password: "<OS_PASSWORD>"
+      project_id: "<OS_PROJECT_ID>"
+      project_name: "<OS_PROJECT_NAME>"
+      user_domain_name: "<OS_USER_DOMAIN_NAME>"
+    region_name: "<OS_REGION_NAME>"
+    interface: "public"
+    verify: false
+    identity_api_version: 3
+' | base64 -w0
+)"
+
+# OpenStack region and network configuration. External network ID is only needed if multiple external networks exist.
+export OPENSTACK_EXTERNAL_NETWORK_ID=""
+export OPENSTACK_FAILURE_DOMAIN="nova"
+
+# OpenStack machine conifugration
+export OPENSTACK_IMAGE_NAME=ubuntu-20.04
+export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.large
+export OPENSTACK_NODE_MACHINE_FLAVOR=m1.large
+export OPENSTACK_SSH_KEY_NAME=neo

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -1,0 +1,128 @@
+# Based on: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.6.3/cluster-template.yaml
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["10.1.0.0/16"] # CIDR block used by Calico.
+    serviceDomain: "cluster.local"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+    kind: OpenStackCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: MicroK8sControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: ${CLUSTER_NAME}-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: OpenStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  cloudName: ${OPENSTACK_CLOUD}
+  identityRef:
+    name: ${CLUSTER_NAME}-cloud-config
+    kind: Secret
+  nodeCidr: 10.6.0.0/24
+  disablePortSecurity: true
+  dnsNameservers: []
+  externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID:=""}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: MicroK8sControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  controlPlaneConfig:
+    initConfiguration:
+      joinTokenTTLInSecs: 9000
+      addons:
+        - dns
+        - ingress
+    clusterConfiguration:
+      portCompatibilityRemap: true
+  machineTemplate:
+    infrastructureTemplate:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+      kind: OpenStackMachineTemplate
+      name: "${CLUSTER_NAME}-control-plane"
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+  version: "v${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
+      image: ${OPENSTACK_IMAGE_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      cloudName: ${OPENSTACK_CLOUD}
+      identityRef:
+        name: ${CLUSTER_NAME}-cloud-config
+        kind: Secret
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT:=1}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      failureDomain: ${OPENSTACK_FAILURE_DOMAIN:=nova}
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: MicroK8sConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+        kind: OpenStackMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      cloudName: ${OPENSTACK_CLOUD}
+      identityRef:
+        name: ${CLUSTER_NAME}-cloud-config
+        kind: Secret
+      flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
+      image: ${OPENSTACK_IMAGE_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: MicroK8sConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      clusterConfiguration:
+        portCompatibilityRemap: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}-cloud-config
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+data:
+  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
+  cacert: ${OPENSTACK_CLOUD_CACERT_B64:=Cg==}


### PR DESCRIPTION
### Summary

Add cluster templates for AWS and OpenStack. Document their usage, update the example cluster deployment in the README and make a few minor fixes.