### PR TITLE
Update RBAC rules for the bootstrap provider

### DIFF
--- a/bootstrap-components.yaml
+++ b/bootstrap-components.yaml
@@ -926,6 +926,19 @@ metadata:
   name: capi-microk8s-bootstrap-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
   - microk8sconfigs
@@ -951,6 +964,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  - machines
+  - machines/finalizers
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,19 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
   - microk8sconfigs
@@ -31,3 +44,20 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  - machines
+  - machines/finalizers
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -94,6 +94,8 @@ const (
 //+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=microk8sconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=microk8sconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=microk8sconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/finalizers;clusters/status;machines;machines/finalizers;machines/status,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
### Summary

Add RBAC rules for clusters, machines, secrets, and configmaps to the bootstrap provider. Roles are generated from kubebuilder rules in the controller code. Also re-run `make component` to update the `bootstrap-components.yaml` manifest.

### Testing

1. Deploy management cluster with RBAC enabled:

```
snap install microk8s --classic
microk8s enable rbac dns
```

2. Install and configure clusterctl

3. Deploy a cluster on OpenStack and AWS (based on the cluster templates found in https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/22

Testing is manual for now.