### PR TITLE
build controller images for amd64 and arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM golang:1.17 as builder
 
+ARG arch
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,7 +17,7 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$arch go build -a -ldflags '-s -w' -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,22 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+docker-build-%: ## Build docker image with the manager.
+	docker build -t ${IMG}-$* . --build-arg arch=$*
+docker-build: docker-build-amd64 docker-build-arm64
 
 .PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+docker-push-%: docker-build-% ## Push docker image with the manager.
+	docker push ${IMG}-$*
+docker-push: docker-push-amd64 docker-push-arm64
+
+.PHONY: docker-manifest
+docker-manifest: docker-push ## Push docker multi-arch manifest.
+	docker manifest rm ${IMG} || true
+	docker manifest create ${IMG} --amend ${IMG}-amd64 --amend ${IMG}-arm64
+	docker manifest annotate ${IMG} ${IMG}-amd64 --arch=amd64
+	docker manifest annotate ${IMG} ${IMG}-arm64 --arch=arm64
+	docker manifest push ${IMG}
 
 .PHONY: lint
 lint: golangci-lint ## Lint the codebase


### PR DESCRIPTION
### Summary

Build controller images for amd64 and arm64.

```bash
make docker-build       # makes $IMG-amd64 and $IMG-arm64
make docker-manifest    # makes $IMG multi-arch image
```

### Example

A development build is pushed to `neoaggelos/capmbp:dev1`:

```bash
# docker manifest inspect neoaggelos/capmbp:dev1
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:adcc532b34e03a95f11af6d740550ed83b4c61c7d7333679af8a0a231497344d",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 738,
         "digest": "sha256:cd0c02ff00c37e6c4dd49e3843c7b607a5d1702419d28f59a9dcf8b18a27c660",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```