### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,17 @@ jobs:
       - name: Retrieve build information
         id: build
         run: |
-          echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "Releasing ${VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          sed -i "s,docker.io/cdkbot/capi-bootstrap-provider-microk8s:latest,cdkbot/capi-bootstrap-provider-microk8s:${VERSION//v}," bootstrap-components.yaml
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v0.1.14
         with:
+          name: 'Release ${{ env.VERSION }}'
           files: |
             bootstrap-components.yaml
             metadata.yaml
           generate_release_notes: true
-          draft: true
-          prerelease: ${{ contains(steps.build.outputs.version, 'rc' }}
+          draft: false
+          prerelease: ${{ contains(env.VERSION, 'rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Retrieve build information
+        id: build
+        run: |
+          echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          files: |
+            bootstrap-components.yaml
+            metadata.yaml
+          generate_release_notes: true
+          draft: true
+          prerelease: ${{ contains(steps.build.outputs.version, 'rc' }}


### PR DESCRIPTION
## Summary

Add a GitHub action workflow that creates releases on tag pushes.

*NOTE*: Releases are pushed as draft at the moment, to facilitate with testing.