### PR TITLE
Add proxy configuration and cleanup cluster templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ secret "microk8s-aws-kubeconfig" deleted
 
 > *NOTE*: Ensure that you have properly deployed the OpenStack infrastructure provider prior to executing the commands below. See [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
 
+Create a cloud-config secret for the OpenStack API in the management cluster with the following command. Make sure to replace the OpenStack credentials in the command below to match your OpenStack cloud. If unsure, consult "Horizon" > "API Access" > "Download OpenStack RC File" > "OpenStack clouds.yaml File".
+
+```bash
+sudo microk8s kubectl create -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-config
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+stringData:
+  cacert: ''
+  clouds.yaml: |
+    clouds:
+      openstack:
+        auth:
+          auth_url: "${OS_AUTH_URL}"
+          username: "${OS_USERNAME}"
+          password: "${OS_PASSWORD}"
+          project_name: "${OS_PROJECT_NAME}"
+          user_domain_name: "${OS_USER_DOMAIN_NAME}"
+        region_name: "${OS_REGION_NAME}"
+        interface: "public"
+        verify: false
+        identity_api_version: 3
+EOF
+```
+
 Generate a cluster template with:
 
 ```bash

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -1,5 +1,5 @@
 # Kubernetes cluster configuration
-export KUBERNETES_VERSION=1.24.0
+export KUBERNETES_VERSION=1.25.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   controlPlaneConfig:
     initConfiguration:
-      joinTokenTTLInSecs: 9000
+      joinTokenTTLInSecs: 900000
       IPinIP: true
       addons:
         - dns

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -3,26 +3,9 @@ export KUBERNETES_VERSION=1.24.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 
-# OpenStack credentials configuration
-# If unsure, consult "Horizon" > "API Access" > "Download OpenStack RC File" > "OpenStack clouds.yaml File"
+# OpenStack credentials configuration. No changes needed if you followed the README.
 export OPENSTACK_CLOUD=openstack
-export OPENSTACK_CLOUD_CACERT_B64="Cg=="
-export OPENSTACK_CLOUD_YAML_B64="$(echo '
-clouds:
-  openstack:
-    auth:
-      auth_url: "<OS_AUTH_URL>"
-      username: "<OS_USERNAME>"
-      password: "<OS_PASSWORD>"
-      project_id: "<OS_PROJECT_ID>"
-      project_name: "<OS_PROJECT_NAME>"
-      user_domain_name: "<OS_USER_DOMAIN_NAME>"
-    region_name: "<OS_REGION_NAME>"
-    interface: "public"
-    verify: false
-    identity_api_version: 3
-' | base64 -w0
-)"
+export OPENSTACK_CLOUD_CONFIG_SECRET_NAME=cloud-config
 
 # OpenStack region and network configuration. External network ID is only needed if multiple external networks exist.
 export OPENSTACK_EXTERNAL_NETWORK_ID=""
@@ -30,6 +13,6 @@ export OPENSTACK_FAILURE_DOMAIN="nova"
 
 # OpenStack machine conifugration
 export OPENSTACK_IMAGE_NAME=ubuntu-20.04
-export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.large
-export OPENSTACK_NODE_MACHINE_FLAVOR=m1.large
-export OPENSTACK_SSH_KEY_NAME=neo
+export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.medium
+export OPENSTACK_NODE_MACHINE_FLAVOR=m1.medium
+export OPENSTACK_SSH_KEY_NAME=my-ssh-key

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -16,3 +16,8 @@ export OPENSTACK_IMAGE_NAME=ubuntu-20.04
 export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.medium
 export OPENSTACK_NODE_MACHINE_FLAVOR=m1.medium
 export OPENSTACK_SSH_KEY_NAME=my-ssh-key
+
+# (optional) Containerd HTTP proxy configuration. Leave empty if not required.
+export CONTAINERD_HTTP_PROXY=""
+export CONTAINERD_HTTPS_PROXY=""
+export CONTAINERD_NO_PROXY=""

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -1,5 +1,5 @@
 # Kubernetes cluster configuration
-export KUBERNETES_VERSION=1.24.0
+export KUBERNETES_VERSION=1.25.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -5,10 +5,6 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  clusterNetwork:
-    pods:
-      cidrBlocks: ["10.1.0.0/16"] # CIDR block used by Calico.
-    serviceDomain: "cluster.local"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
     kind: OpenStackCluster

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   controlPlaneConfig:
     initConfiguration:
-      joinTokenTTLInSecs: 9000
+      joinTokenTTLInSecs: 900000
       addons:
         - dns
         - ingress

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   cloudName: ${OPENSTACK_CLOUD}
   identityRef:
-    name: ${CLUSTER_NAME}-cloud-config
+    name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
     kind: Secret
   nodeCidr: 10.6.0.0/24
   disablePortSecurity: true
@@ -65,7 +65,7 @@ spec:
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
+        name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
         kind: Secret
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -101,7 +101,7 @@ spec:
     spec:
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
+        name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
         kind: Secret
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
@@ -116,13 +116,3 @@ spec:
     spec:
       clusterConfiguration:
         portCompatibilityRemap: true
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ${CLUSTER_NAME}-cloud-config
-  labels:
-    clusterctl.cluster.x-k8s.io/move: "true"
-data:
-  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
-  cacert: ${OPENSTACK_CLOUD_CACERT_B64:=Cg==}

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -43,6 +43,9 @@ spec:
       addons:
         - dns
         - ingress
+      httpProxy: "${CONTAINERD_HTTP_PROXY:=}"
+      httpsProxy: "${CONTAINERD_HTTPS_PROXY:=}"
+      noProxy: "${CONTAINERD_NO_PROXY:=}"
     clusterConfiguration:
       portCompatibilityRemap: true
   machineTemplate:
@@ -116,3 +119,7 @@ spec:
     spec:
       clusterConfiguration:
         portCompatibilityRemap: true
+      initConfiguration:
+        httpProxy: "${CONTAINERD_HTTP_PROXY:=}"
+        httpsProxy: "${CONTAINERD_HTTPS_PROXY:=}"
+        noProxy: "${CONTAINERD_NO_PROXY:=}"


### PR DESCRIPTION
### Summary

Add (optional) containerd http proxy configuration on OpenStack cluster template and verify it is funcional. This PR also includes some small housekeeping-related changes to the same parts of the code.

Proxy configuration was validated with the configs below, and has been fixed with the work in https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/39

### Changes

- Add containerd http proxy configuration on openstack template
- Remove unused parts of the openstack cluster template
- Deploy kubernetes 1.25 by default
- Cleanup openstack secret generation, so that you do not need OpenStack credentials every time a cluster template is generated.