### PR TITLE
Fixes for OpenStack cluster template

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ stringData:
           password: "${OS_PASSWORD}"
           project_name: "${OS_PROJECT_NAME}"
           user_domain_name: "${OS_USER_DOMAIN_NAME}"
+          project_domain_name: "${OS_PROJECT_DOMAIN_NAME}"
         region_name: "${OS_REGION_NAME}"
         interface: "public"
         verify: false

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -17,6 +17,10 @@ export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.medium
 export OPENSTACK_NODE_MACHINE_FLAVOR=m1.medium
 export OPENSTACK_SSH_KEY_NAME=my-ssh-key
 
+# OpenStack network configuration
+export OPENSTACK_NETWORK_CIDR=10.6.0.0/24
+export OPENSTACK_DNS_NAMESERVERS=
+
 # (optional) Containerd HTTP proxy configuration. Leave empty if not required.
 export CONTAINERD_HTTP_PROXY=""
 export CONTAINERD_HTTPS_PROXY=""

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -23,9 +23,9 @@ spec:
   identityRef:
     name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
     kind: Secret
-  nodeCidr: 10.6.0.0/24
+  nodeCidr: ${OPENSTACK_NETWORK_CIDR}
   disablePortSecurity: true
-  dnsNameservers: []
+  dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
   externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID:=""}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
### Summary

Fixes for the OpenStack cluster template.

### Changes

- Configurable DNS nameservers for the OpenStack network. This is useful when OpenStack is using OVN, so an empty nameserver list on the network results in machines unable to resolve DNS. The list is empty by default.
- Configurable OpenStack network CIDR, useful in case of conflicts.