### PR TITLE
Add confinement option to install microk8s snaps

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -72,6 +72,7 @@ type InitConfiguration struct {
 
 	// The confinement (strict or classic) configuration
 	// +optional
+	// +kubebuilder:validation:Enum=classic;strict
 	Confinement string `json:"Confinement,omitempty"`
 }
 

--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -69,6 +69,10 @@ type InitConfiguration struct {
 	// The optional IPinIP configuration
 	// +optional
 	IPinIP bool `json:"IPinIP,omitempty"`
+
+	// The confinement (strict or classic) configuration
+	// +optional
+	Confinement string `json:"Confinement,omitempty"`
 }
 
 // MicroK8sConfigSpec defines the desired state of MicroK8sConfig

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -61,6 +61,12 @@ spec:
                 type: object
               initConfiguration:
                 properties:
+                  Confinement:
+                    description: The confinement (strict or classic) configuration
+                    enum:
+                    - classic
+                    - strict
+                    type: string
                   IPinIP:
                     description: The optional IPinIP configuration
                     type: boolean

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -67,6 +67,12 @@ spec:
                         type: object
                       initConfiguration:
                         properties:
+                          Confinement:
+                            description: The confinement (strict or classic) configuration
+                            enum:
+                            - classic
+                            - strict
+                            type: string
                           IPinIP:
                             description: The optional IPinIP configuration
                             type: boolean

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -53,7 +53,7 @@ type ControlPlaneInitInput struct {
 	Addons []string
 	// IPinIP defines whether Calico will use IPinIP mode for cluster networking.
 	IPinIP bool
-	// Confinement specifies a classic or strict deployment of microk8s snap
+	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
 }
 

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -93,6 +93,12 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
 	}
 
+	// strict confinement is only available for microk8s v1.25+
+	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
+		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
+	}
+	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+
 	cloudConfig := NewBaseCloudConfig()
 	cloudConfig.WriteFiles = append(
 		cloudConfig.WriteFiles,
@@ -103,7 +109,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
+		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		"microk8s refresh-certs /var/tmp",

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -53,6 +53,8 @@ type ControlPlaneInitInput struct {
 	Addons []string
 	// IPinIP defines whether Calico will use IPinIP mode for cluster networking.
 	IPinIP bool
+	// Confinement specifies a classic or strict deployment of microk8s snap
+	Confinement string
 }
 
 func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
@@ -101,7 +103,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor()),
+		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		"microk8s refresh-certs /var/tmp",

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -44,7 +44,60 @@ func TestControlPlaneInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25`,
+			`/capi-scripts/00-install-microk8s.sh 1.25 `,
+			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
+			`microk8s status --wait-ready`,
+			`microk8s refresh-certs /var/tmp`,
+			`/capi-scripts/10-configure-calico-ipip.sh true`,
+			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,
+			`/capi-scripts/10-configure-dqlite-port.sh "2379"`,
+			`/capi-scripts/10-configure-apiserver.sh "DNS" "k8s.my-domain.com"`,
+			`/capi-scripts/20-microk8s-enable.sh "dns"`,
+			`microk8s add-node --token-ttl 10000 --token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
+		}))
+
+		g.Expect(cloudConfig.WriteFiles).To(ContainElements(
+			cloudinit.File{
+				Content:     "CA KEY DATA",
+				Path:        "/var/tmp/ca.key",
+				Permissions: "0600",
+				Owner:       "root:root",
+			},
+			cloudinit.File{
+				Content:     "CA CERT DATA",
+				Path:        "/var/tmp/ca.crt",
+				Permissions: "0600",
+				Owner:       "root:root",
+			},
+		))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestControlPlaneConfinementInit(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
+			CAKey:                `CA KEY DATA`,
+			CACert:               `CA CERT DATA`,
+			ControlPlaneEndpoint: "k8s.my-domain.com",
+			KubernetesVersion:    "v1.25.2",
+			ClusterAgentPort:     "30000",
+			DqlitePort:           "2379",
+			IPinIP:               true,
+			Token:                strings.Repeat("a", 32),
+			TokenTTL:             10000,
+			Confinement:          "strict",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
+			`set -x`,
+			`/capi-scripts/00-disable-host-services.sh`,
+			`/capi-scripts/00-install-microk8s.sh 1.25 strict`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`microk8s refresh-certs /var/tmp`,

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -44,7 +44,7 @@ func TestControlPlaneInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25 `,
+			`/capi-scripts/00-install-microk8s.sh "1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`microk8s refresh-certs /var/tmp`,
@@ -97,7 +97,7 @@ func TestControlPlaneConfinementInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25 strict`,
+			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`microk8s refresh-certs /var/tmp`,

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -44,7 +44,7 @@ func TestControlPlaneInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.25 --classic"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`microk8s refresh-certs /var/tmp`,
@@ -97,7 +97,7 @@ func TestControlPlaneConfinementInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`microk8s refresh-certs /var/tmp`,

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -45,9 +45,9 @@ type ControlPlaneJoinInput struct {
 	ContainerdNoProxy string
 	// IPinIP defines whether Calico will use IPinIP mode for cluster networking.
 	IPinIP bool
-	// JoinNodeIP is the IP address of the node to join
+	// JoinNodeIP is the IP address of the node to join.
 	JoinNodeIP string
-	// Confinement specifies a classic or strict deployment of microk8s snap
+	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
 }
 

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -73,12 +73,18 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
 	}
 
+	// strict confinement is only available for microk8s v1.25+
+	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
+		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
+	}
+	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+
 	cloudConfig := NewBaseCloudConfig()
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
+		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		fmt.Sprintf("%s %v", scriptPath(configureCalicoIPIPScript), input.IPinIP),

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -47,6 +47,8 @@ type ControlPlaneJoinInput struct {
 	IPinIP bool
 	// JoinNodeIP is the IP address of the node to join
 	JoinNodeIP string
+	// Confinement specifies a classic or strict deployment of microk8s snap
+	Confinement string
 }
 
 func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
@@ -76,7 +78,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor()),
+		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		fmt.Sprintf("%s %v", scriptPath(configureCalicoIPIPScript), input.IPinIP),

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -43,7 +43,7 @@ func TestControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25 `,
+			`/capi-scripts/00-install-microk8s.sh "1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-calico-ipip.sh true`,
@@ -80,7 +80,7 @@ func TestConfinementControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25 strict`,
+			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-calico-ipip.sh true`,

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -43,7 +43,44 @@ func TestControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.25`,
+			`/capi-scripts/00-install-microk8s.sh 1.25 `,
+			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
+			`microk8s status --wait-ready`,
+			`/capi-scripts/10-configure-calico-ipip.sh true`,
+			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,
+			`/capi-scripts/10-configure-dqlite-port.sh "2379"`,
+			`microk8s status --wait-ready`,
+			`/capi-scripts/20-microk8s-join.sh "10.0.3.39:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
+			`/capi-scripts/10-configure-apiserver.sh "DNS" "k8s.my-domain.com"`,
+			`microk8s add-node --token-ttl 10000 --token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
+		}))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestConfinementControlPlaneJoin(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
+			ControlPlaneEndpoint: "k8s.my-domain.com",
+			KubernetesVersion:    "v1.25.2",
+			ClusterAgentPort:     "30000",
+			DqlitePort:           "2379",
+			IPinIP:               true,
+			Token:                strings.Repeat("a", 32),
+			TokenTTL:             10000,
+			JoinNodeIP:           "10.0.3.39",
+			Confinement:          "strict",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
+			`set -x`,
+			`/capi-scripts/00-disable-host-services.sh`,
+			`/capi-scripts/00-install-microk8s.sh 1.25 strict`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-calico-ipip.sh true`,

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -43,7 +43,7 @@ func TestControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.25 --classic"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-calico-ipip.sh true`,
@@ -80,7 +80,7 @@ func TestConfinementControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-calico-ipip.sh true`,

--- a/controllers/cloudinit/embed.go
+++ b/controllers/cloudinit/embed.go
@@ -18,7 +18,6 @@ package cloudinit
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"path/filepath"
 )

--- a/controllers/cloudinit/scripts/00-install-microk8s.sh
+++ b/controllers/cloudinit/scripts/00-install-microk8s.sh
@@ -6,7 +6,7 @@
 # Assumptions:
 #   - snap is installed
 
-while ! snap install microk8s --channel "${1}"; do
+while ! snap install microk8s "${1}"; do
   echo "Failed to install MicroK8s snap, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/scripts/00-install-microk8s.sh
+++ b/controllers/cloudinit/scripts/00-install-microk8s.sh
@@ -6,7 +6,7 @@
 # Assumptions:
 #   - snap is installed
 
-while ! snap install microk8s "${1}"; do
+while ! snap install microk8s ${1}; do
   echo "Failed to install MicroK8s snap, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/scripts/00-install-microk8s.sh
+++ b/controllers/cloudinit/scripts/00-install-microk8s.sh
@@ -1,12 +1,20 @@
 #!/bin/bash -xe
 
 # Usage:
-#   $0 $microk8s_snap_channel
+#   $0 $microk8s_snap_channel $confinement
 #
 # Assumptions:
 #   - snap is installed
 
-while ! snap install microk8s --classic --channel "${1}"; do
+install_cmd="snap install microk8s --channel"
+
+if [[ "${2}" == "strict" ]]; then
+  install_cmd="$install_cmd "${1}"-strict"
+else
+  install_cmd="$install_cmd "${1}" --classic"
+fi
+
+while ! $install_cmd; do
   echo "Failed to install MicroK8s snap, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/scripts/00-install-microk8s.sh
+++ b/controllers/cloudinit/scripts/00-install-microk8s.sh
@@ -1,20 +1,12 @@
 #!/bin/bash -xe
 
 # Usage:
-#   $0 $microk8s_snap_channel $confinement
+#   $0 $microk8s_snap_args
 #
 # Assumptions:
 #   - snap is installed
 
-install_cmd="snap install microk8s --channel"
-
-if [[ "${2}" == "strict" ]]; then
-  install_cmd="$install_cmd "${1}"-strict"
-else
-  install_cmd="$install_cmd "${1}" --classic"
-fi
-
-while ! $install_cmd; do
+while ! snap install microk8s --channel "${1}"; do
   echo "Failed to install MicroK8s snap, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/utils.go
+++ b/controllers/cloudinit/utils.go
@@ -18,20 +18,17 @@ package cloudinit
 
 import (
 	"fmt"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
 func createInstallArgs(confinement string, kubernetesVersion *version.Version) string {
-	kubernetesMajorVersion := strconv.FormatUint(uint64(kubernetesVersion.Major()), 10)
-	kubernetesMinorVersion := strconv.FormatUint(uint64(kubernetesVersion.Minor()), 10)
-	installChannel := fmt.Sprintf("%s.%s", kubernetesMajorVersion, kubernetesMinorVersion)
+	installChannel := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
 	var installArgs string
 	if confinement == "strict" {
-		installArgs = fmt.Sprintf("%s-strict", installChannel)
+		installArgs = fmt.Sprintf("--channel %s-strict", installChannel)
 	} else {
-		installArgs = fmt.Sprintf("%s --classic", installChannel)
+		installArgs = fmt.Sprintf("--channel %s --classic", installChannel)
 	}
 
 	return installArgs

--- a/controllers/cloudinit/utils.go
+++ b/controllers/cloudinit/utils.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinit
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+func createInstallArgs(confinement string, kubernetesVersion *version.Version) string {
+	kubernetesMajorVersion := strconv.FormatUint(uint64(kubernetesVersion.Major()), 10)
+	kubernetesMinorVersion := strconv.FormatUint(uint64(kubernetesVersion.Minor()), 10)
+	installChannel := fmt.Sprintf("%s.%s", kubernetesMajorVersion, kubernetesMinorVersion)
+	var installArgs string
+	if confinement == "strict" {
+		installArgs = fmt.Sprintf("%s-strict", installChannel)
+	} else {
+		installArgs = fmt.Sprintf("%s --classic", installChannel)
+	}
+
+	return installArgs
+}

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -38,6 +38,8 @@ type WorkerInput struct {
 	ContainerdNoProxy string
 	// JoinNodeIP is the IP address of the node to join
 	JoinNodeIP string
+	// Confinement specifies a classic or strict deployment of microk8s snap
+	Confinement string
 }
 
 func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
@@ -58,7 +60,7 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor()),
+		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		fmt.Sprintf("%s %q", scriptPath(configureClusterAgentPortScript), input.ClusterAgentPort),

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -36,9 +36,9 @@ type WorkerInput struct {
 	ContainerdHTTPSProxy string
 	// ContainerdNoProxy is no_proxy configuration for containerd.
 	ContainerdNoProxy string
-	// JoinNodeIP is the IP address of the node to join
+	// JoinNodeIP is the IP address of the node to join.
 	JoinNodeIP string
-	// Confinement specifies a classic or strict deployment of microk8s snap
+	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
 }
 

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -55,12 +55,18 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
 	}
 
+	// strict confinement is only available for microk8s v1.25+
+	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
+		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
+	}
+	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+
 	cloudConfig := NewBaseCloudConfig()
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
 		scriptPath(disableHostServicesScript),
-		fmt.Sprintf("%s %d.%d %s", scriptPath(installMicroK8sScript), kubernetesVersion.Major(), kubernetesVersion.Minor(), input.Confinement),
+		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),
 		"microk8s status --wait-ready",
 		fmt.Sprintf("%s %q", scriptPath(configureClusterAgentPortScript), input.ClusterAgentPort),

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -39,7 +39,7 @@ func TestWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.24 `,
+			`/capi-scripts/00-install-microk8s.sh "1.24 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,
@@ -56,7 +56,7 @@ func TestConfinementWorkerJoin(t *testing.T) {
 		g := NewWithT(t)
 
 		cloudConfig, err := cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
-			KubernetesVersion: "v1.24.3",
+			KubernetesVersion: "v1.25.3",
 			ClusterAgentPort:  "30000",
 			Token:             strings.Repeat("a", 32),
 			JoinNodeIP:        "10.0.3.194",
@@ -67,7 +67,7 @@ func TestConfinementWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.24 strict`,
+			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -39,7 +39,7 @@ func TestWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.24 --classic"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.24 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,
@@ -67,7 +67,7 @@ func TestConfinementWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh "1.25-strict"`,
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -39,7 +39,35 @@ func TestWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-disable-host-services.sh`,
-			`/capi-scripts/00-install-microk8s.sh 1.24`,
+			`/capi-scripts/00-install-microk8s.sh 1.24 `,
+			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
+			`microk8s status --wait-ready`,
+			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,
+			`/capi-scripts/20-microk8s-join.sh "10.0.3.194:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" --worker`,
+		}))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestConfinementWorkerJoin(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
+			KubernetesVersion: "v1.24.3",
+			ClusterAgentPort:  "30000",
+			Token:             strings.Repeat("a", 32),
+			JoinNodeIP:        "10.0.3.194",
+			Confinement:       "strict",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
+			`set -x`,
+			`/capi-scripts/00-disable-host-services.sh`,
+			`/capi-scripts/00-install-microk8s.sh 1.24 strict`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cluster-agent-port.sh "30000"`,


### PR DESCRIPTION
**Summary**
As of now, we only installed and deployed `--classic` confined microk8s snaps in the control plane and worker nodes during bootstrapping. In microk8s, instead of the default confinement being `strict`, we use strict channels for strict confinement, like `1.25-strict`.  So, we have changed the `00-install-microk8s.sh` to take confinement as an argument, a blank argument defaults to classic, whilst giving a `"strict"` argument installs a strict snap.

Test for the same is added for `controlplane_init_test`, `controlplane_join_test`, and `worker_join_test`.

As of now, we still deploy the snaps in classic confinement but now have the option to deploy in strict mode too.