### PR TITLE
Add option to set `risk-level` for k8s version in channel

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -74,6 +74,12 @@ type InitConfiguration struct {
 	// +optional
 	// +kubebuilder:validation:Enum=classic;strict
 	Confinement string `json:"Confinement,omitempty"`
+
+	// The risk-level (stable, candidate, beta, or edge) for the snaps
+	// +optional
+	// +kubebuilder:validation:Enum=stable;candidate;beta;edge
+	// +kubebuilder:default:=stable
+	RiskLevel string `json:"RiskLevel,omitempty"`
 }
 
 // MicroK8sConfigSpec defines the desired state of MicroK8sConfig

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -55,6 +55,8 @@ type ControlPlaneInitInput struct {
 	IPinIP bool
 	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
+	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
+	RiskLevel string
 }
 
 func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
@@ -87,7 +89,6 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	}
 
 	// figure out snap channel from KubernetesVersion
-	// TODO: support specifying the snap channel
 	kubernetesVersion, err := version.ParseSemantic(input.KubernetesVersion)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
@@ -97,7 +98,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
 		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
 	}
-	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
 
 	cloudConfig := NewBaseCloudConfig()
 	cloudConfig.WriteFiles = append(

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -76,7 +76,7 @@ func TestControlPlaneInit(t *testing.T) {
 	})
 }
 
-func TestControlPlaneConfinementInit(t *testing.T) {
+func TestConfinementControlPlaneInit(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -122,6 +122,28 @@ func TestControlPlaneConfinementInit(t *testing.T) {
 				Permissions: "0600",
 				Owner:       "root:root",
 			},
+		))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestRiskLevelControlPlaneInit(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
+			KubernetesVersion: "v1.25.2",
+			Token:             strings.Repeat("a", 32),
+			TokenTTL:          10000,
+			Confinement:       "strict",
+			RiskLevel:         "edge",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/edge"`,
 		))
 
 		_, err = cloudinit.GenerateCloudConfig(cloudConfig)

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -49,6 +49,8 @@ type ControlPlaneJoinInput struct {
 	JoinNodeIP string
 	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
+	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
+	RiskLevel string
 }
 
 func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
@@ -67,7 +69,6 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 	}
 
 	// figure out snap channel from KubernetesVersion
-	// TODO: support specifying the snap channel
 	kubernetesVersion, err := version.ParseSemantic(input.KubernetesVersion)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
@@ -77,7 +78,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
 		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
 	}
-	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
 
 	cloudConfig := NewBaseCloudConfig()
 

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -96,3 +96,25 @@ func TestConfinementControlPlaneJoin(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
+
+func TestRiskLevelControlPlaneJoin(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
+			KubernetesVersion: "v1.25.2",
+			Token:             strings.Repeat("a", 32),
+			TokenTTL:          10000,
+			Confinement:       "strict",
+			RiskLevel:         "candidate",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/candidate"`,
+		))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}

--- a/controllers/cloudinit/utils.go
+++ b/controllers/cloudinit/utils.go
@@ -22,13 +22,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
-func createInstallArgs(confinement string, kubernetesVersion *version.Version) string {
+func createInstallArgs(confinement string, riskLevel string, kubernetesVersion *version.Version) string {
 	installChannel := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
 	var installArgs string
 	if confinement == "strict" {
-		installArgs = fmt.Sprintf("--channel %s-strict", installChannel)
+		if riskLevel != "" {
+			installArgs = fmt.Sprintf("--channel %s-strict/%s", installChannel, riskLevel)
+		} else {
+			installArgs = fmt.Sprintf("--channel %s-strict", installChannel)
+		}
 	} else {
-		installArgs = fmt.Sprintf("--channel %s --classic", installChannel)
+		if riskLevel != "" {
+			installArgs = fmt.Sprintf("--channel %s/%s --classic", installChannel, riskLevel)
+		} else {
+			installArgs = fmt.Sprintf("--channel %s --classic", installChannel)
+		}
 	}
 
 	return installArgs

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -40,6 +40,8 @@ type WorkerInput struct {
 	JoinNodeIP string
 	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
+	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
+	RiskLevel string
 }
 
 func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
@@ -49,7 +51,6 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 	}
 
 	// figure out snap channel from KubernetesVersion
-	// TODO: support specifying the snap channel
 	kubernetesVersion, err := version.ParseSemantic(input.KubernetesVersion)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes version %q is not a semantic version: %w", input.KubernetesVersion, err)
@@ -59,7 +60,7 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 	if input.Confinement == "strict" && kubernetesVersion.Minor() < 25 {
 		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
 	}
-	installArgs := createInstallArgs(input.Confinement, kubernetesVersion)
+	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
 
 	cloudConfig := NewBaseCloudConfig()
 

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -78,3 +78,24 @@ func TestConfinementWorkerJoin(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
+
+func TestRiskLevelWorkerJoin(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cloudConfig, err := cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
+			KubernetesVersion: "v1.25.3",
+			Token:             strings.Repeat("a", 32),
+			Confinement:       "strict",
+			RiskLevel:         "beta",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
+			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/beta"`,
+		))
+
+		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}


### PR DESCRIPTION
**Summary**

Every snap has four risk levels: stable, candidate, beta, and edge (used `--channel=<track-version>/<risk>`). This PR adds an option to add the risk levels for the version in the microk8s snap channels.

**File changes**

- apis/v1beta1/microk8sconfig_types.go: Added a new option for `RiskLevel` in the specs.
- controllers/cloudinit/*: Added the `RiskLevel` option in the init configs for `controlplane_init`, `controlplane_join`, and `worker_join`. Added corresponding tests.