### PR TITLE
Add extraWriteFiles configuration to bootstrap provider

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -80,6 +80,22 @@ type InitConfiguration struct {
 	// +kubebuilder:validation:Enum=stable;candidate;beta;edge
 	// +kubebuilder:default:=stable
 	RiskLevel string `json:"RiskLevel,omitempty"`
+
+	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
+	// +optional
+	ExtraWriteFiles []CloudInitWriteFile `json:"extraWriteFiles,omitempty"`
+}
+
+// CloudInitWriteFile is a file that will be injected by cloud-init
+type CloudInitWriteFile struct {
+	// Content of the file to create.
+	Content string `json:"content"`
+	// Path where the file should be created.
+	Path string `json:"path"`
+	// Permissions of the file to create, e.g. "0600"
+	Permissions string `json:"permissions"`
+	// Owner of the file to create, e.g. "root:root"
+	Owner string `json:"owner"`
 }
 
 // MicroK8sConfigSpec defines the desired state of MicroK8sConfig

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -91,6 +91,32 @@ spec:
                       schemas to the latest internal value, and may reject unrecognized
                       values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
+                  extraWriteFiles:
+                    description: ExtraWriteFiles is a list of extra files to inject
+                      with cloud-init.
+                    items:
+                      description: CloudInitWriteFile is a file that will be injected
+                        by cloud-init
+                      properties:
+                        content:
+                          description: Content of the file to create.
+                          type: string
+                        owner:
+                          description: Owner of the file to create, e.g. "root:root"
+                          type: string
+                        path:
+                          description: Path where the file should be created.
+                          type: string
+                        permissions:
+                          description: Permissions of the file to create, e.g. "0600"
+                          type: string
+                      required:
+                      - content
+                      - owner
+                      - path
+                      - permissions
+                      type: object
+                    type: array
                   httpProxy:
                     description: The optional http proxy configuration
                     type: string

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -70,6 +70,16 @@ spec:
                   IPinIP:
                     description: The optional IPinIP configuration
                     type: boolean
+                  RiskLevel:
+                    default: stable
+                    description: The risk-level (stable, candidate, beta, or edge)
+                      for the snaps
+                    enum:
+                    - stable
+                    - candidate
+                    - beta
+                    - edge
+                    type: string
                   addons:
                     description: List of addons to be enabled upon cluster creation
                     items:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -98,6 +98,33 @@ spec:
                               convert recognized schemas to the latest internal value,
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
+                          extraWriteFiles:
+                            description: ExtraWriteFiles is a list of extra files
+                              to inject with cloud-init.
+                            items:
+                              description: CloudInitWriteFile is a file that will
+                                be injected by cloud-init
+                              properties:
+                                content:
+                                  description: Content of the file to create.
+                                  type: string
+                                owner:
+                                  description: Owner of the file to create, e.g. "root:root"
+                                  type: string
+                                path:
+                                  description: Path where the file should be created.
+                                  type: string
+                                permissions:
+                                  description: Permissions of the file to create,
+                                    e.g. "0600"
+                                  type: string
+                              required:
+                              - content
+                              - owner
+                              - path
+                              - permissions
+                              type: object
+                            type: array
                           httpProxy:
                             description: The optional http proxy configuration
                             type: string

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -76,6 +76,16 @@ spec:
                           IPinIP:
                             description: The optional IPinIP configuration
                             type: boolean
+                          RiskLevel:
+                            default: stable
+                            description: The risk-level (stable, candidate, beta,
+                              or edge) for the snaps
+                            enum:
+                            - stable
+                            - candidate
+                            - beta
+                            - edge
+                            type: string
                           addons:
                             description: List of addons to be enabled upon cluster
                               creation

--- a/controllers/cloudinit/cloudinit_common_test.go
+++ b/controllers/cloudinit/cloudinit_common_test.go
@@ -1,0 +1,65 @@
+package cloudinit_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/canonical/cluster-api-bootstrap-provider-microk8s/controllers/cloudinit"
+	. "github.com/onsi/gomega"
+)
+
+func TestCloudConfigInput(t *testing.T) {
+	t.Run("ChannelAndRiskLevel", func(t *testing.T) {
+		for _, tc := range []struct {
+			name            string
+			makeCloudConfig func() (*cloudinit.CloudConfig, error)
+		}{
+			{
+				name: "ControlPlaneInit",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						TokenTTL:          100,
+						Confinement:       "strict",
+						RiskLevel:         "edge",
+					})
+				},
+			},
+			{
+				name: "ControlPlaneJoin",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						TokenTTL:          100,
+						Confinement:       "strict",
+						RiskLevel:         "edge",
+					})
+				},
+			},
+			{
+				name: "Worker",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						Confinement:       "strict",
+						RiskLevel:         "edge",
+					})
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+				c, err := tc.makeCloudConfig()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(c.RunCommands).To(ContainElement(`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/edge"`))
+
+				_, err = cloudinit.GenerateCloudConfig(c)
+				g.Expect(err).NotTo(HaveOccurred())
+			})
+		}
+	})
+}

--- a/controllers/cloudinit/cloudinit_common_test.go
+++ b/controllers/cloudinit/cloudinit_common_test.go
@@ -1,9 +1,26 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cloudinit_test
 
 import (
 	"strings"
 	"testing"
 
+	"github.com/canonical/cluster-api-bootstrap-provider-microk8s/apis/v1beta1"
 	"github.com/canonical/cluster-api-bootstrap-provider-microk8s/controllers/cloudinit"
 	. "github.com/onsi/gomega"
 )
@@ -56,6 +73,68 @@ func TestCloudConfigInput(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				g.Expect(c.RunCommands).To(ContainElement(`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/edge"`))
+
+				_, err = cloudinit.GenerateCloudConfig(c)
+				g.Expect(err).NotTo(HaveOccurred())
+			})
+		}
+	})
+
+	t.Run("ExtraWriteFiles", func(t *testing.T) {
+		files := []v1beta1.CloudInitWriteFile{{
+			Content:     "contents",
+			Path:        "/tmp/path",
+			Permissions: "0644",
+			Owner:       "root:root",
+		}}
+		for _, tc := range []struct {
+			name            string
+			makeCloudConfig func() (*cloudinit.CloudConfig, error)
+		}{
+			{
+				name: "ControlPlaneInit",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						TokenTTL:          100,
+						ExtraWriteFiles:   cloudinit.WriteFilesFromAPI(files),
+					})
+				},
+			},
+			{
+				name: "ControlPlaneJoin",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						TokenTTL:          100,
+						ExtraWriteFiles:   cloudinit.WriteFilesFromAPI(files),
+					})
+				},
+			},
+			{
+				name: "Worker",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
+						KubernetesVersion: "v1.25.0",
+						Token:             strings.Repeat("a", 32),
+						ExtraWriteFiles:   cloudinit.WriteFilesFromAPI(files),
+					})
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+				c, err := tc.makeCloudConfig()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(c.WriteFiles).To(ContainElement(cloudinit.File{
+					Content:     "contents",
+					Path:        "/tmp/path",
+					Permissions: "0644",
+					Owner:       "root:root",
+				}))
 
 				_, err = cloudinit.GenerateCloudConfig(c)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -57,6 +57,8 @@ type ControlPlaneInitInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
+	ExtraWriteFiles []File
 }
 
 func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
@@ -106,6 +108,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 		File{Content: input.CAKey, Path: filepath.Join("/var", "tmp", "ca.key"), Permissions: "0600", Owner: "root:root"},
 		File{Content: input.CACert, Path: filepath.Join("/var", "tmp", "ca.crt"), Permissions: "0600", Owner: "root:root"},
 	)
+	cloudConfig.WriteFiles = append(cloudConfig.WriteFiles, input.ExtraWriteFiles...)
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -128,25 +128,3 @@ func TestConfinementControlPlaneInit(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
-
-func TestRiskLevelControlPlaneInit(t *testing.T) {
-	t.Run("Simple", func(t *testing.T) {
-		g := NewWithT(t)
-
-		cloudConfig, err := cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
-			KubernetesVersion: "v1.25.2",
-			Token:             strings.Repeat("a", 32),
-			TokenTTL:          10000,
-			Confinement:       "strict",
-			RiskLevel:         "edge",
-		})
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
-			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/edge"`,
-		))
-
-		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
-}

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -51,6 +51,8 @@ type ControlPlaneJoinInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
+	ExtraWriteFiles []File
 }
 
 func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
@@ -81,6 +83,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
 
 	cloudConfig := NewBaseCloudConfig()
+	cloudConfig.WriteFiles = append(cloudConfig.WriteFiles, input.ExtraWriteFiles...)
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -96,25 +96,3 @@ func TestConfinementControlPlaneJoin(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
-
-func TestRiskLevelControlPlaneJoin(t *testing.T) {
-	t.Run("Simple", func(t *testing.T) {
-		g := NewWithT(t)
-
-		cloudConfig, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
-			KubernetesVersion: "v1.25.2",
-			Token:             strings.Repeat("a", 32),
-			TokenTTL:          10000,
-			Confinement:       "strict",
-			RiskLevel:         "candidate",
-		})
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
-			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/candidate"`,
-		))
-
-		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
-}

--- a/controllers/cloudinit/utils.go
+++ b/controllers/cloudinit/utils.go
@@ -19,6 +19,7 @@ package cloudinit
 import (
 	"fmt"
 
+	bootstrapclusterxk8siov1beta1 "github.com/canonical/cluster-api-bootstrap-provider-microk8s/apis/v1beta1"
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
@@ -40,4 +41,20 @@ func createInstallArgs(confinement string, riskLevel string, kubernetesVersion *
 	}
 
 	return installArgs
+}
+
+func WriteFilesFromAPI(files []bootstrapclusterxk8siov1beta1.CloudInitWriteFile) []File {
+	if len(files) == 0 {
+		return nil
+	}
+	result := make([]File, 0, len(files))
+	for _, f := range files {
+		result = append(result, File{
+			Content:     f.Content,
+			Path:        f.Path,
+			Permissions: f.Permissions,
+			Owner:       f.Owner,
+		})
+	}
+	return result
 }

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -42,6 +42,8 @@ type WorkerInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
+	ExtraWriteFiles []File
 }
 
 func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
@@ -63,6 +65,7 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
 
 	cloudConfig := NewBaseCloudConfig()
+	cloudConfig.WriteFiles = append(cloudConfig.WriteFiles, input.ExtraWriteFiles...)
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -78,24 +78,3 @@ func TestConfinementWorkerJoin(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
-
-func TestRiskLevelWorkerJoin(t *testing.T) {
-	t.Run("Simple", func(t *testing.T) {
-		g := NewWithT(t)
-
-		cloudConfig, err := cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
-			KubernetesVersion: "v1.25.3",
-			Token:             strings.Repeat("a", 32),
-			Confinement:       "strict",
-			RiskLevel:         "beta",
-		})
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(cloudConfig.RunCommands[2]).To(Equal(
-			`/capi-scripts/00-install-microk8s.sh "--channel 1.25-strict/beta"`,
-		))
-
-		_, err = cloudinit.GenerateCloudConfig(cloudConfig)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
-}

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -302,6 +302,7 @@ func (r *MicroK8sConfigReconciler) handleClusterNotInitialized(ctx context.Conte
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 	}
 	if controlPlaneInput.TokenTTL == 0 {
 		controlPlaneInput.TokenTTL = 315569260
@@ -394,6 +395,7 @@ func (r *MicroK8sConfigReconciler) handleJoiningControlPlaneNode(ctx context.Con
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 	}
 	if controlPlaneInput.TokenTTL == 0 {
 		controlPlaneInput.TokenTTL = 315569260
@@ -476,6 +478,7 @@ func (r *MicroK8sConfigReconciler) handleJoiningWorkerNode(ctx context.Context, 
 		KubernetesVersion: *machine.Spec.Version,
 		ClusterAgentPort:  portOfNodeToConnectTo,
 		JoinNodeIP:        ipOfNodeToConnectTo,
+		ExtraWriteFiles:   cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 	}
 
 	if c := microk8sConfig.Spec.InitConfiguration; c != nil {


### PR DESCRIPTION
### Summary

Allow injecting custom files to the cloud-init template. This is preliminary work required for the upcoming vsphere cluster template.

### Notes

Add a separate type for the API cloud init config files, we don't want to mix the public API with the internal cloudinit.File type.