### PR TITLE
Fix panics when joining worker nodes without an initConfiguration

### DIFF
--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -480,14 +480,15 @@ func (r *MicroK8sConfigReconciler) handleJoiningWorkerNode(ctx context.Context, 
 		KubernetesVersion: *machine.Spec.Version,
 		ClusterAgentPort:  portOfNodeToConnectTo,
 		JoinNodeIP:        ipOfNodeToConnectTo,
-		ExtraWriteFiles:   cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
-		ExtraKubeletArgs:  microk8sConfig.Spec.InitConfiguration.ExtraKubeletArgs,
 	}
 
 	if c := microk8sConfig.Spec.InitConfiguration; c != nil {
 		workerInput.ContainerdHTTPSProxy = c.HTTPSProxy
 		workerInput.ContainerdHTTPProxy = c.HTTPProxy
 		workerInput.ContainerdNoProxy = c.NoProxy
+
+		workerInput.ExtraKubeletArgs = c.ExtraKubeletArgs
+		workerInput.ExtraWriteFiles = cloudinit.WriteFilesFromAPI(c.ExtraWriteFiles)
 	}
 	bootstrapInitData, err := cloudinit.NewJoinWorker(workerInput)
 	if err != nil {


### PR DESCRIPTION
### Summary

The `InitConfiguration` for worker nodes may be nil. In that case, make sure that we do not access things that we shouldn't.

