### PR TITLE
Do not fail if community addons cannot be enabled

### DIFF
--- a/controllers/cloudinit/scripts/20-microk8s-enable.sh
+++ b/controllers/cloudinit/scripts/20-microk8s-enable.sh
@@ -8,7 +8,7 @@
 #   - microk8s apiserver is up and running
 
 # enable community addons, this is for free and avoids confusion if addons are failing to install
-microk8s enable community
+microk8s enable community || true
 
 while [[ "$@" != "" ]]; do
   microk8s enable "$1"


### PR DESCRIPTION
### Summary

MicroK8s versions < 1.24 do not have a separate repository for community addons, so make sure that bootstrapping does not fail.