### PR TITLE
Update cloud templates with upgrade strategy field

### DIFF
--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -14,4 +14,4 @@ export AWS_NODE_MACHINE_FLAVOR=t3.large
 export AWS_SSH_KEY_NAME=my-ssh-key
 
 # Upgrade configuration
-export UPGRADE_STRATEGY=RollingUpgrade
+export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -12,3 +12,6 @@ export AWS_PUBLIC_IP=false
 export AWS_CONTROL_PLANE_MACHINE_FLAVOR=t3.large
 export AWS_NODE_MACHINE_FLAVOR=t3.large
 export AWS_SSH_KEY_NAME=my-ssh-key
+
+# Upgrade configuration
+export UPGRADE_STRATEGY=RollingUpgrade

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -45,6 +45,7 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
+  upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate

--- a/templates/cluster-template-azure.rc
+++ b/templates/cluster-template-azure.rc
@@ -25,3 +25,6 @@ export AZURE_SSH_PUBLIC_KEY_B64=""
 export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export CLUSTER_IDENTITY_NAME="cluster-identity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
+
+# Upgrade configuration
+export UPGRADE_STRATEGY=RollingUpgrade

--- a/templates/cluster-template-azure.rc
+++ b/templates/cluster-template-azure.rc
@@ -27,4 +27,4 @@ export CLUSTER_IDENTITY_NAME="cluster-identity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
 # Upgrade configuration
-export UPGRADE_STRATEGY=RollingUpgrade
+export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-azure.yaml
+++ b/templates/cluster-template-azure.yaml
@@ -57,6 +57,7 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
+  upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/templates/cluster-template-gcp.rc
+++ b/templates/cluster-template-gcp.rc
@@ -15,4 +15,4 @@ export GCP_NODE_MACHINE_TYPE=n1-standard-2
 export IMAGE_ID=projects/$GCP_PROJECT/global/images/ubuntu-2204
 
 # Upgrade configuration
-export UPGRADE_STRATEGY=RollingUpgrade
+export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-gcp.rc
+++ b/templates/cluster-template-gcp.rc
@@ -13,3 +13,6 @@ export GCP_PUBLIC_IP=true              # set to false if you have configured a c
 export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
 export GCP_NODE_MACHINE_TYPE=n1-standard-2
 export IMAGE_ID=projects/$GCP_PROJECT/global/images/ubuntu-2204
+
+# Upgrade configuration
+export UPGRADE_STRATEGY=RollingUpgrade

--- a/templates/cluster-template-gcp.yaml
+++ b/templates/cluster-template-gcp.yaml
@@ -47,6 +47,7 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
+  upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPMachineTemplate

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -25,3 +25,6 @@ export OPENSTACK_DNS_NAMESERVERS=
 export CONTAINERD_HTTP_PROXY=""
 export CONTAINERD_HTTPS_PROXY=""
 export CONTAINERD_NO_PROXY=""
+
+# Upgrade configuration
+export UPGRADE_STRATEGY=RollingUpgrade

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -27,4 +27,4 @@ export CONTAINERD_HTTPS_PROXY=""
 export CONTAINERD_NO_PROXY=""
 
 # Upgrade configuration
-export UPGRADE_STRATEGY=RollingUpgrade
+export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -51,6 +51,7 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
+  upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate


### PR DESCRIPTION
**Summary**
Based on: https://github.com/canonical/cluster-api-control-plane-provider-microk8s/pull/35
After updating our control plane specs with the new filed `upgradeStrategy` we also need to update our cloud templates to reflect the change. This field takes in two values: `RollingUpgrades` and `InPlaceUpgrade`, and updates the nodes and machine based on the type of upgrade specified, `RolloutUpgrades` being the default.