### PR TITLE
gcp: ensure worker nodes publicIP is set

### DIFF
--- a/templates/cluster-template-gcp.yaml
+++ b/templates/cluster-template-gcp.yaml
@@ -91,6 +91,7 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: ${GCP_PUBLIC_IP}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: MicroK8sConfigTemplate


### PR DESCRIPTION
### Summary

In the GCP cluster template, ensure we set the `publicIP` property for machine templates of the worker nodes, same as we do for the control plane.

