### PR TITLE
Fix reading risklevel and confinement from spec

### DIFF
--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -38,6 +38,7 @@ func TestControlPlaneInit(t *testing.T) {
 			IPinIP:               true,
 			Token:                strings.Repeat("a", 32),
 			TokenTTL:             10000,
+			Confinement:          "classic",
 		})
 		g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -302,6 +302,8 @@ func (r *MicroK8sConfigReconciler) handleClusterNotInitialized(ctx context.Conte
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		Confinement:          microk8sConfig.Spec.InitConfiguration.Confinement,
+		RiskLevel:            microk8sConfig.Spec.InitConfiguration.RiskLevel,
 		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 		ExtraKubeletArgs:     microk8sConfig.Spec.InitConfiguration.ExtraKubeletArgs,
 	}
@@ -487,6 +489,9 @@ func (r *MicroK8sConfigReconciler) handleJoiningWorkerNode(ctx context.Context, 
 		workerInput.ContainerdHTTPSProxy = c.HTTPSProxy
 		workerInput.ContainerdHTTPProxy = c.HTTPProxy
 		workerInput.ContainerdNoProxy = c.NoProxy
+
+		workerInput.Confinement = c.Confinement
+		workerInput.RiskLevel = c.RiskLevel
 
 		workerInput.ExtraKubeletArgs = c.ExtraKubeletArgs
 		workerInput.ExtraWriteFiles = cloudinit.WriteFilesFromAPI(c.ExtraWriteFiles)

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -398,6 +398,8 @@ func (r *MicroK8sConfigReconciler) handleJoiningControlPlaneNode(ctx context.Con
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		RiskLevel:            microk8sConfig.Spec.InitConfiguration.RiskLevel,
+		Confinement:          microk8sConfig.Spec.InitConfiguration.Confinement,
 		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 		ExtraKubeletArgs:     microk8sConfig.Spec.InitConfiguration.ExtraKubeletArgs,
 	}

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -13,5 +13,9 @@ export AWS_CONTROL_PLANE_MACHINE_FLAVOR=t3.large
 export AWS_NODE_MACHINE_FLAVOR=t3.large
 export AWS_SSH_KEY_NAME=my-ssh-key
 
+# (optional) Snap risk level and confinement
+export SNAP_RISKLEVEL=""
+export SNAP_CONFINEMENT=""
+
 # Upgrade configuration
 export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -36,6 +36,8 @@ spec:
       addons:
         - dns
         - ingress
+      riskLevel: "${SNAP_RISKLEVEL:=}"
+      confinement: "${SNAP_CONFINEMENT:=}"
     clusterConfiguration:
       portCompatibilityRemap: true
   machineTemplate:
@@ -103,3 +105,6 @@ spec:
     spec:
       clusterConfiguration:
         portCompatibilityRemap: true
+      initConfiguration:
+        riskLevel: "${SNAP_RISKLEVEL:=}"
+        confinement: "${SNAP_CONFINEMENT:=}"

--- a/templates/cluster-template-azure.rc
+++ b/templates/cluster-template-azure.rc
@@ -26,5 +26,10 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export CLUSTER_IDENTITY_NAME="cluster-identity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
+# (optional) Snap risk level and confinement
+export SNAP_RISKLEVEL=""
+export SNAP_CONFINEMENT=""
+
+
 # Upgrade configuration
 export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-azure.yaml
+++ b/templates/cluster-template-azure.yaml
@@ -48,6 +48,8 @@ spec:
       addons:
         - dns
         - ingress
+      riskLevel: "${SNAP_RISKLEVEL:=}"
+      confinement: "${SNAP_CONFINEMENT:=}"
     clusterConfiguration:
       portCompatibilityRemap: true
   machineTemplate:
@@ -117,6 +119,9 @@ spec:
     spec:
       clusterConfiguration:
         portCompatibilityRemap: true
+      initConfiguration:
+        riskLevel: "${SNAP_RISKLEVEL:=}"
+        confinement: "${SNAP_CONFINEMENT:=}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity

--- a/templates/cluster-template-gcp.rc
+++ b/templates/cluster-template-gcp.rc
@@ -14,5 +14,10 @@ export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
 export GCP_NODE_MACHINE_TYPE=n1-standard-2
 export IMAGE_ID=projects/$GCP_PROJECT/global/images/ubuntu-2204
 
+# (optional) Snap risk level and confinement
+export SNAP_RISKLEVEL=""
+export SNAP_CONFINEMENT=""
+
+
 # Upgrade configuration
 export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-gcp.yaml
+++ b/templates/cluster-template-gcp.yaml
@@ -38,6 +38,8 @@ spec:
       addons:
         - dns
         - ingress
+      riskLevel: "${SNAP_RISKLEVEL:=}"
+      confinement: "${SNAP_CONFINEMENT:=}"
     clusterConfiguration:
       portCompatibilityRemap: true
   machineTemplate:
@@ -103,3 +105,6 @@ spec:
     spec:
       clusterConfiguration:
         portCompatibilityRemap: true
+      initConfiguration:
+        riskLevel: "${SNAP_RISKLEVEL:=}"
+        confinement: "${SNAP_CONFINEMENT:=}"

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -26,5 +26,9 @@ export CONTAINERD_HTTP_PROXY=""
 export CONTAINERD_HTTPS_PROXY=""
 export CONTAINERD_NO_PROXY=""
 
+# (optional) Snap risk level and confinement
+export SNAP_RISKLEVEL=""
+export SNAP_CONFINEMENT=""
+
 # Upgrade configuration
 export UPGRADE_STRATEGY=SmartUpgrade

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -42,6 +42,8 @@ spec:
       httpProxy: "${CONTAINERD_HTTP_PROXY:=}"
       httpsProxy: "${CONTAINERD_HTTPS_PROXY:=}"
       noProxy: "${CONTAINERD_NO_PROXY:=}"
+      riskLevel: "${SNAP_RISKLEVEL:=}"
+      confinement: "${SNAP_CONFINEMENT:=}"
     clusterConfiguration:
       portCompatibilityRemap: true
   machineTemplate:
@@ -120,3 +122,5 @@ spec:
         httpProxy: "${CONTAINERD_HTTP_PROXY:=}"
         httpsProxy: "${CONTAINERD_HTTPS_PROXY:=}"
         noProxy: "${CONTAINERD_NO_PROXY:=}"
+        riskLevel: "${SNAP_RISKLEVEL:=}"
+        confinement: "${SNAP_CONFINEMENT:=}"


### PR DESCRIPTION
### Summary

The fields `riskLevel` and `confinement` were not read from the spec before. Now we patch them to be read here,

### Testing

Tested locally by deploying a cluster on Openstack with new risk level and confinement.