### PR TITLE
Introduce two snapstore proxy configuration options

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -81,6 +81,14 @@ type InitConfiguration struct {
 	// +kubebuilder:default:=stable
 	RiskLevel string `json:"riskLevel,omitempty"`
 
+	// The snap store proxy domain
+	// +optional
+	SnapstoreProxyDomain string `json:"snapstoreProxyDomain,omitempty"`
+
+	// The snap store proxy ID
+	// +optional
+	SnapstoreProxyId string `json:"snapstoreProxyId,omitempty"`
+
 	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
 	// +optional
 	ExtraWriteFiles []CloudInitWriteFile `json:"extraWriteFiles,omitempty"`

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -145,6 +145,12 @@ spec:
                     - beta
                     - edge
                     type: string
+                  snapstoreProxyDomain:
+                    description: The snap store proxy domain
+                    type: string
+                  snapstoreProxyId:
+                    description: The snap store proxy ID
+                    type: string
                 type: object
             type: object
           status:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -153,6 +153,12 @@ spec:
                             - beta
                             - edge
                             type: string
+                          snapstoreProxyDomain:
+                            description: The snap store proxy domain
+                            type: string
+                          snapstoreProxyId:
+                            description: The snap store proxy ID
+                            type: string
                         type: object
                     type: object
                 type: object

--- a/controllers/cloudinit/cloudinit_common_test.go
+++ b/controllers/cloudinit/cloudinit_common_test.go
@@ -224,4 +224,55 @@ func TestCloudConfigInput(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("SnapstoreProxy", func(t *testing.T) {
+		for _, tc := range []struct {
+			name            string
+			makeCloudConfig func() (*cloudinit.CloudConfig, error)
+		}{
+			{
+				name: "ControlPlaneInit",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInitInput{
+						KubernetesVersion:    "v1.25.0",
+						Token:                strings.Repeat("a", 32),
+						TokenTTL:             100,
+						SnapstoreProxyDomain: "snapstore.domain.com",
+						SnapstoreProxyId:     "ID123456789",
+					})
+				},
+			},
+			{
+				name: "ControlPlaneJoin",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
+						KubernetesVersion:    "v1.25.0",
+						Token:                strings.Repeat("a", 32),
+						TokenTTL:             100,
+						SnapstoreProxyDomain: "snapstore.domain.com",
+						SnapstoreProxyId:     "ID123456789",
+					})
+				},
+			},
+			{
+				name: "Worker",
+				makeCloudConfig: func() (*cloudinit.CloudConfig, error) {
+					return cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
+						KubernetesVersion:    "v1.25.0",
+						Token:                strings.Repeat("a", 32),
+						SnapstoreProxyDomain: "snapstore.domain.com",
+						SnapstoreProxyId:     "ID123456789",
+					})
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+				c, err := tc.makeCloudConfig()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(c.RunCommands).To(ContainElement(`/capi-scripts/00-configure-snapstore-proxy.sh "snapstore.domain.com" "ID123456789"`))
+			})
+		}
+	})
 }

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -57,6 +57,10 @@ type ControlPlaneInitInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
+	SnapstoreProxyDomain string
+	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
+	SnapstoreProxyId string
 	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
 	ExtraWriteFiles []File
 	// ExtraKubeletArgs is a list of arguments to add to kubelet.
@@ -122,6 +126,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	}
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
+		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -43,6 +43,7 @@ func TestControlPlaneInit(t *testing.T) {
 
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -53,6 +53,10 @@ type ControlPlaneJoinInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
+	SnapstoreProxyDomain string
+	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
+	SnapstoreProxyId string
 	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
 	ExtraWriteFiles []File
 	// ExtraKubeletArgs is a list of arguments to add to kubelet.
@@ -102,6 +106,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
+		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -43,6 +43,7 @@ func TestControlPlaneJoin(t *testing.T) {
 
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/embed.go
+++ b/controllers/cloudinit/embed.go
@@ -34,6 +34,9 @@ const (
 	// cloudConfigTemplate is the template to render the cloud-config for the instances.
 	cloudConfigTemplate script = "cloud-config-template"
 
+	// snapstoreProxyScript configures a snapstore proxy.
+	snapstoreProxyScript script = "00-configure-snapstore-proxy.sh"
+
 	// disableHostServicesScript disables services like containerd or kubelet from the host OS image.
 	disableHostServicesScript script = "00-disable-host-services.sh"
 
@@ -72,6 +75,7 @@ const (
 )
 
 var allScripts = []script{
+	snapstoreProxyScript,
 	disableHostServicesScript,
 	installMicroK8sScript,
 	configureCertLB,

--- a/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
+++ b/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
@@ -6,8 +6,6 @@
 # Assumptions:
 #   - snapd is installed
 
-set -x
-
 if [ "$#" -ne 2 ] || [ -z "${1}" ] || [ -z "${2}" ] ; then
   echo "Using the default snapstore"
   exit 0

--- a/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
+++ b/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
@@ -6,17 +6,21 @@
 # Assumptions:
 #   - snapd is installed
 
+set -x
+
 if [ "$#" -ne 2 ] || [ -z "${1}" ] || [ -z "${2}" ] ; then
   echo "Using the default snapstore"
   exit 0
 fi
 
-while ! snap install curl; do
-  echo "Failed to install curl, will retry"
-  sleep 5
-done
+if ! type -P curl ; then
+  while ! snap install curl; do
+    echo "Failed to install curl, will retry"
+    sleep 5
+  done
+fi
 
-while ! /snap/bin/curl -sL http://"${1}"/v2/auth/store/assertions | snap ack /dev/stdin ; do
+while ! curl -sL http://"${1}"/v2/auth/store/assertions | snap ack /dev/stdin ; do
   echo "Failed to ACK store assertions, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
+++ b/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -xe
+
+# Usage:
+#   $0 $snapstore-domain $snapstore-id
+#
+# Assumptions:
+#   - snapd is installed
+
+if [ "$#" -ne 2 ] || [ -z "${1}" ] || [ -z "${2}" ] ; then
+  echo "Using the default snapstore"
+  exit 0
+fi
+
+while ! snap install curl; do
+  echo "Failed to install curl, will retry"
+  sleep 5
+done
+
+while ! /snap/bin/curl -sL http://"${1}"/v2/auth/store/assertions | snap ack /dev/stdin ; do
+  echo "Failed to ACK store assertions, will retry"
+  sleep 5
+done
+
+while ! snap set core proxy.store="${2}" ; do
+  echo "Failed to configure snapd with stire ID, will retry"
+  sleep 5
+done

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -46,6 +46,10 @@ type WorkerInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
+	SnapstoreProxyDomain string
+	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
+	SnapstoreProxyId string
 	// ExtraWriteFiles is a list of extra files to inject with cloud-init.
 	ExtraWriteFiles []File
 	// ExtraKubeletArgs is a list of arguments to add to kubelet.
@@ -91,6 +95,7 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		"set -x",
+		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -40,6 +40,7 @@ func TestWorkerJoin(t *testing.T) {
 
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.24 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -302,6 +302,8 @@ func (r *MicroK8sConfigReconciler) handleClusterNotInitialized(ctx context.Conte
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		SnapstoreProxyDomain: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyDomain,
+		SnapstoreProxyId:     microk8sConfig.Spec.InitConfiguration.SnapstoreProxyId,
 		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 		ExtraKubeletArgs:     microk8sConfig.Spec.InitConfiguration.ExtraKubeletArgs,
 	}
@@ -396,6 +398,8 @@ func (r *MicroK8sConfigReconciler) handleJoiningControlPlaneNode(ctx context.Con
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		SnapstoreProxyDomain: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyDomain,
+		SnapstoreProxyId:     microk8sConfig.Spec.InitConfiguration.SnapstoreProxyId,
 		ExtraWriteFiles:      cloudinit.WriteFilesFromAPI(microk8sConfig.Spec.InitConfiguration.ExtraWriteFiles),
 		ExtraKubeletArgs:     microk8sConfig.Spec.InitConfiguration.ExtraKubeletArgs,
 	}
@@ -487,7 +491,8 @@ func (r *MicroK8sConfigReconciler) handleJoiningWorkerNode(ctx context.Context, 
 		workerInput.ContainerdHTTPSProxy = c.HTTPSProxy
 		workerInput.ContainerdHTTPProxy = c.HTTPProxy
 		workerInput.ContainerdNoProxy = c.NoProxy
-
+		workerInput.SnapstoreProxyDomain = c.SnapstoreProxyDomain
+		workerInput.SnapstoreProxyId = c.SnapstoreProxyId
 		workerInput.ExtraKubeletArgs = c.ExtraKubeletArgs
 		workerInput.ExtraWriteFiles = cloudinit.WriteFilesFromAPI(c.ExtraWriteFiles)
 	}


### PR DESCRIPTION
If the user sets the two SnapstoreProxyDomain SnapstoreProxyId configuration options the snapd registers to the designated snapstore proxy.

## Testing
Tested manually based on the instructions in https://docs.ubuntu.com/snap-store-proxy/en/install. In short, in a VM next to the CAPI cluster do:
```
sudo snap install snap-store-proxy
sudo apt install postgresql
```
Get the IP or host endpoint and put it in:
```
sudo snap-proxy config proxy.domain=<IP or host domain>
```

Configure postgress with something like:
```
$ cat ./ps.sql 
CREATE ROLE "snapproxy-user" LOGIN CREATEROLE PASSWORD 'snapproxy-password';

CREATE DATABASE "snapproxy-db" OWNER "snapproxy-user";

\connect "snapproxy-db"

CREATE EXTENSION "btree_gist";
```
and
```
sudo -u postgres psql < ps.sql 
sudo snap-proxy config proxy.db.connection="postgresql://snapproxy-user@localhost:5432/snapproxy-db"
```
Register the proxy:
```
sudo snap-proxy register
```
Get the store proxy ID and endpoint with:
```
snap-proxy status
```

## Do not forget
After merging this work we need to create a tag and have the MicroK8s controlplane provider use the tag so it gets updated with the new spec.
