### PR TITLE
IPinIp config for azure cluster templates

### DIFF
--- a/templates/cluster-template-azure.yaml
+++ b/templates/cluster-template-azure.yaml
@@ -45,6 +45,7 @@ spec:
   controlPlaneConfig:
     initConfiguration:
       joinTokenTTLInSecs: 9000
+      IPinIP: true
       addons:
         - dns
         - ingress


### PR DESCRIPTION
### Summary
There were some errors with change in phase of the machine (particularly the CP machines) from `Provisioned` to `Ready`. This was fixed by introducing the IPinIP conifuration to `true` in Control Plane machine templates.

### Testing
Tested locally by calling cluster up and down multiple times.