### PR TITLE
Fix typo in cloud-init bash scripts

### DIFF
--- a/controllers/cloudinit/scripts/20-microk8s-join.sh
+++ b/controllers/cloudinit/scripts/20-microk8s-join.sh
@@ -53,4 +53,4 @@ if [ ${1} == "no" ]; then
     echo "Waiting for the cluster to come up"
     sleep 5
   done
-then
+fi


### PR DESCRIPTION
Fixes typo inserted with #58