### PR TITLE
Update OpenStack cluster template

### DIFF
--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -21,6 +21,11 @@ export OPENSTACK_SSH_KEY_NAME=my-ssh-key
 export OPENSTACK_NETWORK_CIDR=10.6.0.0/24
 export OPENSTACK_DNS_NAMESERVERS=
 
+# OpenStack control plane configuration.
+# Set this to 'false' to use a simple Floating IP for the control plane (works everywhere)
+# Set this to 'true' to use an Octavia LoadBalancer for the control plane (requires octavia support in the cloud)
+export OPENSTACK_USE_OCTAVIA_LOADBALANCER=false
+
 # (optional) Containerd HTTP proxy configuration. Leave empty if not required.
 export CONTAINERD_HTTP_PROXY=""
 export CONTAINERD_HTTPS_PROXY=""

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -14,7 +14,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -48,14 +48,14 @@ spec:
       portCompatibilityRemap: true
   machineTemplate:
     infrastructureTemplate:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
       kind: OpenStackMachineTemplate
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
   upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -91,10 +91,10 @@ spec:
           kind: MicroK8sConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
         kind: OpenStackMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -19,6 +19,8 @@ kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
+  apiServerLoadBalancer:
+    enabled: ${OPENSTACK_USE_OCTAVIA_LOADBALANCER}
   cloudName: ${OPENSTACK_CLOUD}
   identityRef:
     name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}


### PR DESCRIPTION
### Summary

Update OpenStack Cluster template

Replaces #80 

### Changes

- Add support for using an Octavia LoadBalancer for the control plane endpoint through an option (`OPENSTACK_USE_OCTAVIA_LOADBALANCER=true`)
- Update to latest API version of the openstack cluster template (v1alpha5 is deprecated and will be removed)

