### PR TITLE
skip snap install if microk8s already installed

### DIFF
--- a/controllers/cloudinit/scripts/00-install-microk8s.sh
+++ b/controllers/cloudinit/scripts/00-install-microk8s.sh
@@ -4,7 +4,12 @@
 #   $0 $microk8s_snap_args
 #
 # Assumptions:
-#   - snap is installed
+#   - snapd is installed
+
+if snap list microk8s; do
+  echo "MicroK8s is already installed, will not install"
+  exit 0
+fi
 
 while ! snap install microk8s ${1}; do
   echo "Failed to install MicroK8s snap, will retry"


### PR DESCRIPTION
### Summary

Do not try to install microk8s if it's already installed on the machine.