### PR TITLE
ensure we use InternalIP or ExternalIP machine addresses

### DIFF
--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -48,7 +48,7 @@ type ControlPlaneJoinInput struct {
 	// IPinIP defines whether Calico will use IPinIP mode for cluster networking.
 	IPinIP bool
 	// JoinNodeIPs is the IP addresses of the nodes to join.
-	JoinNodeIPs [2]string
+	JoinNodeIPs []string
 	// Confinement specifies a classic or strict deployment of microk8s snap.
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
@@ -111,8 +111,10 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 		})
 	}
 
-	joinStr := fmt.Sprintf("%s:%s/%s", input.JoinNodeIPs[0], input.ClusterAgentPort, input.Token)
-	joinStrAlt := fmt.Sprintf("%s:%s/%s", input.JoinNodeIPs[1], input.ClusterAgentPort, input.Token)
+	joinURLs := make([]string, 0, len(input.JoinNodeIPs))
+	for _, nodeIP := range input.JoinNodeIPs {
+		joinURLs = append(joinURLs, fmt.Sprintf("%q", fmt.Sprintf("%s:%s/%s", nodeIP, input.ClusterAgentPort, input.Token)))
+	}
 
 	cloudConfig.BootCommands = append(cloudConfig.BootCommands, input.BootCommands...)
 
@@ -130,7 +132,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 		fmt.Sprintf("%s %q", scriptPath(configureDqlitePortScript), input.DqlitePort),
 		"microk8s status --wait-ready",
 		fmt.Sprintf("%s %q %q", scriptPath(configureCertLB), endpointType, input.ControlPlaneEndpoint),
-		fmt.Sprintf("%s no %q %q", scriptPath(microk8sJoinScript), joinStr, joinStrAlt),
+		fmt.Sprintf("%s no %s", scriptPath(microk8sJoinScript), strings.Join(joinURLs, " ")),
 		scriptPath(configureAPIServerScript),
 		fmt.Sprintf("microk8s add-node --token-ttl %v --token %q", input.TokenTTL, input.Token),
 	)

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -28,7 +28,6 @@ func TestControlPlaneJoin(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		g := NewWithT(t)
 
-		joins := [2]string{"10.0.3.39", "10.0.3.40"}
 		cloudConfig, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
 			ControlPlaneEndpoint: "k8s.my-domain.com",
 			KubernetesVersion:    "v1.25.2",
@@ -37,7 +36,7 @@ func TestControlPlaneJoin(t *testing.T) {
 			IPinIP:               true,
 			Token:                strings.Repeat("a", 32),
 			TokenTTL:             10000,
-			JoinNodeIPs:          joins,
+			JoinNodeIPs:          []string{"10.0.3.39", "10.0.3.40", "10.0.3.41"},
 		})
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -55,7 +54,7 @@ func TestControlPlaneJoin(t *testing.T) {
 			`/capi-scripts/10-configure-dqlite-port.sh "2379"`,
 			`microk8s status --wait-ready`,
 			`/capi-scripts/10-configure-cert-for-lb.sh "DNS" "k8s.my-domain.com"`,
-			`/capi-scripts/20-microk8s-join.sh no "10.0.3.39:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "10.0.3.40:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
+			`/capi-scripts/20-microk8s-join.sh no "10.0.3.39:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "10.0.3.40:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "10.0.3.41:30000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
 			`/capi-scripts/10-configure-apiserver.sh`,
 			`microk8s add-node --token-ttl 10000 --token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
 		}))

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -28,13 +28,12 @@ func TestWorkerJoin(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		g := NewWithT(t)
 
-		joins := [2]string{"10.0.3.194", "10.0.3.195"}
 		cloudConfig, err := cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
 			ControlPlaneEndpoint: "capi-aws-apiserver-1647391446.us-east-1.elb.amazonaws.com",
 			KubernetesVersion:    "v1.24.3",
 			ClusterAgentPort:     "30000",
 			Token:                strings.Repeat("a", 32),
-			JoinNodeIPs:          joins,
+			JoinNodeIPs:          []string{"10.0.3.194", "10.0.3.195"},
 		})
 		g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -374,7 +374,7 @@ func (r *MicroK8sConfigReconciler) handleJoiningControlPlaneNode(ctx context.Con
 
 	scope.Info("Creating BootstrapData for the join control plane")
 	ipsOfNodesToConnectTo, err := r.getControlPlaneNodesToJoin(ctx, scope)
-	if err != nil || ipsOfNodesToConnectTo[0] == "" {
+	if err != nil || len(ipsOfNodesToConnectTo) == 0 {
 		scope.Info("Failed to discover a control plane IP, requeueing.")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}


### PR DESCRIPTION
### Summary

Make sure that we use an IP address for the microk8s join commands. This is done by filtering for addresses of type `InternalIP` or `ExternalIP`.

### Changes

- Update `getControlPlaneNodesToJoin` to group the list of control plane addresses by type, then return a list of addresses of the same type. The order of preference is defined as `InternalIP`, then `ExternalIP`. We return the first list of addresses that is not empty.
- Do not use a `[2]string` for the join addresses, but rather return the full slice of found addresses.
- Adjust the `20-microk8s-join.sh` script to accept any number of join urls, not hardcoded to two.
- If no node IPs are found, we print an error and list the addresses that we found (hopefully this should be clear enough in case no IP is set on the machine addresses).


