### PR TITLE
Support watchNamespace for controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,16 +70,22 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var watchNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&watchNamespace, "namespace", "", "Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if watchNamespace != "" {
+		setupLog.Info("Watching cluster-api objects only in namespace for reconciliation", "namespace", watchNamespace)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	restConfig := ctrl.GetConfigOrDie()
@@ -94,6 +100,7 @@ func main() {
 			&corev1.ConfigMap{},
 			&corev1.Secret{},
 		},
+		Namespace: watchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
**What this PR does / why we need it:** This PR adds support for watchNamespace flag for bootstrap-microk8s controller which will restrict the controller to watch cluster-api objects in its namespace only. This is beneficial for certain downstream use cases where there is a separation between controllers and webhooks and one controller is used per namespace.

**Fixes:**
#94 