### PR TITLE
set tls.crt and tls.key on the cluster CA secret

### DIFF
--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -702,6 +702,11 @@ func (r *MicroK8sConfigReconciler) getCA(ctx context.Context, scope *Scope) (cer
 				Name:      scope.Cluster.Name + "-ca",
 			},
 			Data: map[string][]byte{
+				// these are the expected names for the certificate and key
+				"tls.crt": []byte(*newcrt),
+				"tls.key": []byte(*newkey),
+
+				// these are here for backwards-compatibility with older versions of the providers
 				"crt": []byte(*newcrt),
 				"key": []byte(*newkey),
 			},


### PR DESCRIPTION
### Summary

We keep using `"crt"` and `"key"` everywhere else, but also make sure to set the right secret fields