### PR TITLE
Update cluster-template-aws.yaml

### DIFF
--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -20,6 +20,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   region: ${AWS_REGION}
+  imageLookupBaseOS: ubuntu-20.04
   sshKeyName: ${AWS_SSH_KEY_NAME}
   bastion:
     enabled: ${AWS_CREATE_BASTION:=false}


### PR DESCRIPTION
Provider fails to determine the correct base OS for the AMI. It defaults to ubuntu-18.04 as the base OS and there is no matching AMI for ubuntu-18.04 + kubernetes version > 1.28.1. Since we installed the latest version of the track, the provider looks for ubuntu-18.04-v1.28.3 and this image does not exist.