### PR TITLE
Change AWS custom resources api version in cluster-template-aws.yaml

### DIFF
--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -6,11 +6,6 @@ export WORKER_MACHINE_COUNT=1
 # AWS region
 export AWS_REGION="eu-west-1"
 
-# AWS image
-# Use clusterawsadm ami list to verify there is a AMI that
-# matches your desired base os and kubernetes version.
-export AWS_IMAGE_LOOKUP_BASE_OS=
-
 # AWS machine configuration
 export AWS_CREATE_BASTION=true
 export AWS_PUBLIC_IP=false

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -16,7 +16,7 @@ export AWS_CREATE_BASTION=true
 export AWS_PUBLIC_IP=false
 export AWS_CONTROL_PLANE_MACHINE_FLAVOR=t3.large
 export AWS_NODE_MACHINE_FLAVOR=t3.large
-export AWS_SSH_KEY_NAME=microk8s
+export AWS_SSH_KEY_NAME=my-ssh-key
 
 # (optional) Snap risk level and confinement
 export SNAP_RISKLEVEL="stable"

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -1,5 +1,5 @@
 # Kubernetes cluster configuration
-export KUBERNETES_VERSION=1.27.0
+export KUBERNETES_VERSION=1.25.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-aws.rc
+++ b/templates/cluster-template-aws.rc
@@ -1,17 +1,22 @@
 # Kubernetes cluster configuration
-export KUBERNETES_VERSION=1.25.0
+export KUBERNETES_VERSION=1.27.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 
 # AWS region
 export AWS_REGION="eu-west-1"
 
+# AWS image
+# Use clusterawsadm ami list to verify there is a AMI that
+# matches your desired base os and kubernetes version.
+export AWS_IMAGE_LOOKUP_BASE_OS=
+
 # AWS machine configuration
 export AWS_CREATE_BASTION=true
 export AWS_PUBLIC_IP=false
 export AWS_CONTROL_PLANE_MACHINE_FLAVOR=t3.large
 export AWS_NODE_MACHINE_FLAVOR=t3.large
-export AWS_SSH_KEY_NAME=my-ssh-key
+export AWS_SSH_KEY_NAME=microk8s
 
 # (optional) Snap risk level and confinement
 export SNAP_RISKLEVEL="stable"

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -20,7 +20,6 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   region: ${AWS_REGION}
-  imageLookupBaseOS: ${AWS_IMAGE_LOOKUP_BASE_OS}
   sshKeyName: ${AWS_SSH_KEY_NAME}
   bastion:
     enabled: ${AWS_CREATE_BASTION:=false}

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -47,7 +47,7 @@ spec:
       kind: AWSMachineTemplate
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
-  version: "${KUBERNETES_VERSION}"
+  version: "v${KUBERNETES_VERSION}"
   upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/templates/cluster-template-aws.yaml
+++ b/templates/cluster-template-aws.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -14,13 +14,13 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   region: ${AWS_REGION}
-  imageLookupBaseOS: ubuntu-20.04
+  imageLookupBaseOS: ${AWS_IMAGE_LOOKUP_BASE_OS}
   sshKeyName: ${AWS_SSH_KEY_NAME}
   bastion:
     enabled: ${AWS_CREATE_BASTION:=false}
@@ -43,14 +43,14 @@ spec:
       portCompatibilityRemap: true
   machineTemplate:
     infrastructureTemplate:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: AWSMachineTemplate
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
-  version: "v${KUBERNETES_VERSION}"
+  version: "${KUBERNETES_VERSION}"
   upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -82,10 +82,10 @@ spec:
           kind: MicroK8sConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0


### PR DESCRIPTION
Update infrastructure to v1beta2 because v1beta1 is deprecated (https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/tag/v2.4.0).