### PR TITLE
add new SnapstoreProxyScheme field

### DIFF
--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -85,6 +85,10 @@ type InitConfiguration struct {
 	// +optional
 	DisableDefaultCNI bool `json:"disableDefaultCNI,omitempty"`
 
+	// The snap store proxy domain's scheme, e.g. "http" or "https" without '://'
+	// +optional
+	SnapstoreProxyScheme string `json:"snapstoreProxyScheme,omitempty"`
+
 	// The snap store proxy domain
 	// +optional
 	SnapstoreProxyDomain string `json:"snapstoreProxyDomain,omitempty"`

--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -85,7 +85,7 @@ type InitConfiguration struct {
 	// +optional
 	DisableDefaultCNI bool `json:"disableDefaultCNI,omitempty"`
 
-	// The snap store proxy domain's scheme, e.g. "http" or "https" without '://'
+	// The snap store proxy domain's scheme, e.g. "http" or "https" without "://"
 	// +optional
 	SnapstoreProxyScheme string `json:"snapstoreProxyScheme,omitempty"`
 

--- a/apis/v1beta1/microk8sconfig_types.go
+++ b/apis/v1beta1/microk8sconfig_types.go
@@ -86,6 +86,7 @@ type InitConfiguration struct {
 	DisableDefaultCNI bool `json:"disableDefaultCNI,omitempty"`
 
 	// The snap store proxy domain's scheme, e.g. "http" or "https" without "://"
+	// Defaults to "http".
 	// +optional
 	SnapstoreProxyScheme string `json:"snapstoreProxyScheme,omitempty"`
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -182,7 +182,7 @@ spec:
                     type: string
                   snapstoreProxyScheme:
                     description: The snap store proxy domain's scheme, e.g. "http"
-                      or "https" without "://"
+                      or "https" without "://" Defaults to "http".
                     type: string
                 type: object
             type: object

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -182,7 +182,7 @@ spec:
                     type: string
                   snapstoreProxyScheme:
                     description: The snap store proxy domain's scheme, e.g. "http"
-                      or "https" without '://'
+                      or "https" without "://"
                     type: string
                 type: object
             type: object

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigs.yaml
@@ -180,6 +180,10 @@ spec:
                   snapstoreProxyId:
                     description: The snap store proxy ID
                     type: string
+                  snapstoreProxyScheme:
+                    description: The snap store proxy domain's scheme, e.g. "http"
+                      or "https" without '://'
+                    type: string
                 type: object
             type: object
           status:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -191,6 +191,10 @@ spec:
                           snapstoreProxyId:
                             description: The snap store proxy ID
                             type: string
+                          snapstoreProxyScheme:
+                            description: The snap store proxy domain's scheme, e.g.
+                              "http" or "https" without '://'
+                            type: string
                         type: object
                     type: object
                 type: object

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -193,7 +193,7 @@ spec:
                             type: string
                           snapstoreProxyScheme:
                             description: The snap store proxy domain's scheme, e.g.
-                              "http" or "https" without "://"
+                              "http" or "https" without "://" Defaults to "http".
                             type: string
                         type: object
                     type: object

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_microk8sconfigtemplates.yaml
@@ -193,7 +193,7 @@ spec:
                             type: string
                           snapstoreProxyScheme:
                             description: The snap store proxy domain's scheme, e.g.
-                              "http" or "https" without '://'
+                              "http" or "https" without "://"
                             type: string
                         type: object
                     type: object

--- a/controllers/cloudinit/cloudinit_common_test.go
+++ b/controllers/cloudinit/cloudinit_common_test.go
@@ -237,6 +237,7 @@ func TestCloudConfigInput(t *testing.T) {
 						KubernetesVersion:    "v1.25.0",
 						Token:                strings.Repeat("a", 32),
 						TokenTTL:             100,
+						SnapstoreProxyScheme: "https",
 						SnapstoreProxyDomain: "snapstore.domain.com",
 						SnapstoreProxyId:     "ID123456789",
 					})
@@ -249,6 +250,7 @@ func TestCloudConfigInput(t *testing.T) {
 						KubernetesVersion:    "v1.25.0",
 						Token:                strings.Repeat("a", 32),
 						TokenTTL:             100,
+						SnapstoreProxyScheme: "https",
 						SnapstoreProxyDomain: "snapstore.domain.com",
 						SnapstoreProxyId:     "ID123456789",
 					})
@@ -260,6 +262,7 @@ func TestCloudConfigInput(t *testing.T) {
 					return cloudinit.NewJoinWorker(&cloudinit.WorkerInput{
 						KubernetesVersion:    "v1.25.0",
 						Token:                strings.Repeat("a", 32),
+						SnapstoreProxyScheme: "https",
 						SnapstoreProxyDomain: "snapstore.domain.com",
 						SnapstoreProxyId:     "ID123456789",
 					})
@@ -271,7 +274,7 @@ func TestCloudConfigInput(t *testing.T) {
 				c, err := tc.makeCloudConfig()
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(c.RunCommands).To(ContainElement(`/capi-scripts/00-configure-snapstore-proxy.sh "snapstore.domain.com" "ID123456789"`))
+				g.Expect(c.RunCommands).To(ContainElement(`/capi-scripts/00-configure-snapstore-proxy.sh "https" "snapstore.domain.com" "ID123456789"`))
 			})
 		}
 	})

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -59,7 +59,7 @@ type ControlPlaneInitInput struct {
 	RiskLevel string
 	// DisableDefaultCNI specifies whether to disable the default CNI plugin.
 	DisableDefaultCNI bool
-	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	// SnapstoreProxyScheme specifies the scheme (e.g. http or https) of the domain. Defaults to "http".
 	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string
@@ -88,6 +88,10 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	}
 	if input.TokenTTL <= 0 {
 		return nil, fmt.Errorf("join token TTL %q is not a positive number", input.TokenTTL)
+	}
+
+	if input.SnapstoreProxyScheme == "" {
+		input.SnapstoreProxyScheme = "http"
 	}
 
 	// figure out endpoint type

--- a/controllers/cloudinit/controlplane_init.go
+++ b/controllers/cloudinit/controlplane_init.go
@@ -59,6 +59,8 @@ type ControlPlaneInitInput struct {
 	RiskLevel string
 	// DisableDefaultCNI specifies whether to disable the default CNI plugin.
 	DisableDefaultCNI bool
+	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string
 	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
@@ -141,7 +143,7 @@ func NewInitControlPlane(input *ControlPlaneInitInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands, input.PreRunCommands...)
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		fmt.Sprintf("%s %q %q", scriptPath(snapstoreHTTPProxyScript), input.SnapstoreHTTPProxy, input.SnapstoreHTTPSProxy),
-		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
+		fmt.Sprintf("%s %q %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyScheme, input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -46,7 +46,7 @@ func TestControlPlaneInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "http" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/controlplane_init_test.go
+++ b/controllers/cloudinit/controlplane_init_test.go
@@ -46,7 +46,7 @@ func TestControlPlaneInit(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -55,7 +55,7 @@ type ControlPlaneJoinInput struct {
 	RiskLevel string
 	// DisableDefaultCNI specifies whether to use the default CNI plugin.
 	DisableDefaultCNI bool
-	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	// SnapstoreProxyScheme specifies the scheme (e.g https://) of the domain.
 	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -55,7 +55,7 @@ type ControlPlaneJoinInput struct {
 	RiskLevel string
 	// DisableDefaultCNI specifies whether to use the default CNI plugin.
 	DisableDefaultCNI bool
-	// SnapstoreProxyScheme specifies the scheme (e.g https://) of the domain.
+	// SnapstoreProxyScheme specifies the scheme (e.g. http or https) of the domain. Defaults to "http".
 	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string
@@ -103,6 +103,10 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
 	}
 	installArgs := createInstallArgs(input.Confinement, input.RiskLevel, kubernetesVersion)
+
+	if input.SnapstoreProxyScheme == "" {
+		input.SnapstoreProxyScheme = "http"
+	}
 
 	cloudConfig := NewBaseCloudConfig()
 	cloudConfig.WriteFiles = append(cloudConfig.WriteFiles, input.ExtraWriteFiles...)

--- a/controllers/cloudinit/controlplane_join.go
+++ b/controllers/cloudinit/controlplane_join.go
@@ -55,6 +55,8 @@ type ControlPlaneJoinInput struct {
 	RiskLevel string
 	// DisableDefaultCNI specifies whether to use the default CNI plugin.
 	DisableDefaultCNI bool
+	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string
 	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
@@ -123,7 +125,7 @@ func NewJoinControlPlane(input *ControlPlaneJoinInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands, input.PreRunCommands...)
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		fmt.Sprintf("%s %q %q", scriptPath(snapstoreHTTPProxyScript), input.SnapstoreHTTPProxy, input.SnapstoreHTTPSProxy),
-		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
+		fmt.Sprintf("%s %q %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyScheme, input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -44,7 +44,7 @@ func TestControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/controlplane_join_test.go
+++ b/controllers/cloudinit/controlplane_join_test.go
@@ -44,7 +44,7 @@ func TestControlPlaneJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "http" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.25 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
+++ b/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
@@ -1,12 +1,17 @@
 #!/bin/bash -xe
 
 # Usage:
-#   $0 $snapstore-domain $snapstore-id
+#   $0 $snapstore-scheme $snapstore-domain $snapstore-id
+#
+# Arguments:
+#   $snapstore-scheme     The scheme for the domain (e.g. https or http without the ://)
+#   $snapstore-domain     The domain name (e.g. snapstore.domain.com)
+#   $snapstore-id         The store id (e.g. ID123456789)
 #
 # Assumptions:
 #   - snapd is installed
 
-if [ "$#" -ne 2 ] || [ -z "${1}" ] || [ -z "${2}" ] ; then
+if [ "$#" -ne 3 ] || [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ] ; then
   echo "Using the default snapstore"
   exit 0
 fi
@@ -18,12 +23,12 @@ if ! type -P curl ; then
   done
 fi
 
-while ! curl -sL http://"${1}"/v2/auth/store/assertions | snap ack /dev/stdin ; do
+while ! curl -sL "${1}"://"${2}"/v2/auth/store/assertions | snap ack /dev/stdin ; do
   echo "Failed to ACK store assertions, will retry"
   sleep 5
 done
 
-while ! snap set core proxy.store="${2}" ; do
-  echo "Failed to configure snapd with stire ID, will retry"
+while ! snap set core proxy.store="${3}" ; do
+  echo "Failed to configure snapd with store ID, will retry"
   sleep 5
 done

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -46,7 +46,7 @@ type WorkerInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
-	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	// SnapstoreProxyScheme specifies the scheme (e.g http or https) of the domain. Defaults to http.
 	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -46,6 +46,8 @@ type WorkerInput struct {
 	Confinement string
 	// RiskLevel specifies the risk level (strict, candidate, beta, edge) for the snap channels.
 	RiskLevel string
+	// SnapstoreProxyScheme specifies the scheme (i.e https://) of the domain.
+	SnapstoreProxyScheme string
 	// SnapstoreProxyDomain specifies the domain of the snapstore proxy if one is to be used.
 	SnapstoreProxyDomain string
 	// SnapstoreProxyId specifies the snapstore proxy ID if one is to be used.
@@ -110,7 +112,7 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands, input.PreRunCommands...)
 	cloudConfig.RunCommands = append(cloudConfig.RunCommands,
 		fmt.Sprintf("%s %q %q", scriptPath(snapstoreHTTPProxyScript), input.SnapstoreHTTPProxy, input.SnapstoreHTTPSProxy),
-		fmt.Sprintf("%s %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyDomain, input.SnapstoreProxyId),
+		fmt.Sprintf("%s %q %q %q", scriptPath(snapstoreProxyScript), input.SnapstoreProxyScheme, input.SnapstoreProxyDomain, input.SnapstoreProxyId),
 		scriptPath(disableHostServicesScript),
 		fmt.Sprintf("%s %q", scriptPath(installMicroK8sScript), installArgs),
 		fmt.Sprintf("%s %q %q %q", scriptPath(configureContainerdProxyScript), input.ContainerdHTTPProxy, input.ContainerdHTTPSProxy, input.ContainerdNoProxy),

--- a/controllers/cloudinit/worker_join.go
+++ b/controllers/cloudinit/worker_join.go
@@ -85,6 +85,10 @@ func NewJoinWorker(input *WorkerInput) (*CloudConfig, error) {
 		return nil, fmt.Errorf("strict confinement is only available for microk8s v1.25+")
 	}
 
+	if input.SnapstoreProxyScheme == "" {
+		input.SnapstoreProxyScheme = "http"
+	}
+
 	stopApiServerProxyRefreshes := "no"
 	if kubernetesVersion.Minor() > 24 {
 		stopApiServerProxyRefreshes = "yes"

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -40,7 +40,7 @@ func TestWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "http" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.24 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/cloudinit/worker_join_test.go
+++ b/controllers/cloudinit/worker_join_test.go
@@ -40,7 +40,7 @@ func TestWorkerJoin(t *testing.T) {
 		g.Expect(cloudConfig.RunCommands).To(Equal([]string{
 			`set -x`,
 			`/capi-scripts/00-configure-snapstore-http-proxy.sh "" ""`,
-			`/capi-scripts/00-configure-snapstore-proxy.sh "" ""`,
+			`/capi-scripts/00-configure-snapstore-proxy.sh "" "" ""`,
 			`/capi-scripts/00-disable-host-services.sh`,
 			`/capi-scripts/00-install-microk8s.sh "--channel 1.24 --classic"`,
 			`/capi-scripts/10-configure-containerd-proxy.sh "" "" ""`,

--- a/controllers/microk8sconfig_controller.go
+++ b/controllers/microk8sconfig_controller.go
@@ -310,6 +310,7 @@ func (r *MicroK8sConfigReconciler) handleClusterNotInitialized(ctx context.Conte
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		SnapstoreProxyScheme: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyScheme,
 		SnapstoreProxyDomain: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyDomain,
 		SnapstoreProxyId:     microk8sConfig.Spec.InitConfiguration.SnapstoreProxyId,
 		Confinement:          microk8sConfig.Spec.InitConfiguration.Confinement,
@@ -414,6 +415,7 @@ func (r *MicroK8sConfigReconciler) handleJoiningControlPlaneNode(ctx context.Con
 		ContainerdHTTPProxy:  microk8sConfig.Spec.InitConfiguration.HTTPProxy,
 		ContainerdHTTPSProxy: microk8sConfig.Spec.InitConfiguration.HTTPSProxy,
 		ContainerdNoProxy:    microk8sConfig.Spec.InitConfiguration.NoProxy,
+		SnapstoreProxyScheme: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyScheme,
 		SnapstoreProxyDomain: microk8sConfig.Spec.InitConfiguration.SnapstoreProxyDomain,
 		SnapstoreProxyId:     microk8sConfig.Spec.InitConfiguration.SnapstoreProxyId,
 		RiskLevel:            microk8sConfig.Spec.InitConfiguration.RiskLevel,
@@ -515,6 +517,7 @@ func (r *MicroK8sConfigReconciler) handleJoiningWorkerNode(ctx context.Context, 
 		workerInput.ContainerdHTTPSProxy = c.HTTPSProxy
 		workerInput.ContainerdHTTPProxy = c.HTTPProxy
 		workerInput.ContainerdNoProxy = c.NoProxy
+		workerInput.SnapstoreProxyScheme = c.SnapstoreProxyScheme
 		workerInput.SnapstoreProxyDomain = c.SnapstoreProxyDomain
 		workerInput.SnapstoreProxyId = c.SnapstoreProxyId
 		workerInput.SnapstoreHTTPProxy = c.SnapstoreHTTPProxy


### PR DESCRIPTION
Adds a new SnapStoreProxyScheme field to the Microk8sConfig type.

This field is meant to be either `http` or `https` without `://`. For backwards-compatibility reasons this new field has been added because the existing field was called `SnapstoreProxyDomain` and I do not think it's appropriate for a variable with that name to specify the URL scheme.

This addresses https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/issues/108