### PR TITLE
restart snapd after configuring proxy

### DIFF
--- a/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
+++ b/controllers/cloudinit/scripts/00-configure-snapstore-proxy.sh
@@ -32,3 +32,5 @@ while ! snap set core proxy.store="${3}" ; do
   echo "Failed to configure snapd with store ID, will retry"
   sleep 5
 done
+
+systemctl restart snapd


### PR DESCRIPTION
removes the need to restart from preRunCommands like in this example manifest:

```
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: MicroK8sConfigTemplate
metadata:
  name: microk8s-maas-md-0
  namespace: default
spec:
  template:
    spec:
      initConfiguration:
        preRunCommands:
        - |
          cat > /usr/local/share/ca-certificates/pcr_ca.crt << EOF
          ...
          EOF
          sudo update-ca-certificates
          curl -sL .../auth/store/assertions | snap ack /dev/stdin
          snap set core proxy.store=...
          sudo systemctl restart snapd
```

From what I've seen of users configurations they setup the proxy with https manually in preRunCommands, and the last command is a systemctl restart snapd. If they don't restart snapd after setting up certificates snap install fails with an SSL error.

Before 0.6.9 we hardcoded the proxy protocol as http, so we didn't encounter this SSL error, which is why we did not add systemctl restart snapd to the proxy configuration script.