### PR TITLE
chore(join): Limit join retry attempts

### DIFF
--- a/controllers/cloudinit/scripts/20-microk8s-join.sh
+++ b/controllers/cloudinit/scripts/20-microk8s-join.sh
@@ -16,15 +16,23 @@ shift
 
 # Loop over the given join addresses until microk8s join command succeeds.
 joined="false"
+attempts=0
+max_attempts=30
 while [ "$joined" = "false" ]; do
 
   for url in "${@}"; do
+    if [ $attempts -ge $max_attempts ]; then
+      echo "Max join retry limit reached, exiting."
+      exit 1
+    fi
+
     if microk8s join "${url}" $join_args; then
       joined="true"
       break
     fi
 
-    echo "Failed to join MicroK8s cluster, will retry"
+    echo "Failed to join MicroK8s cluster, retrying ($((attempts+1))/$max_attempts)"
+    attempts=$((attempts+1))
     sleep 5
   done
 

--- a/integration/cluster-manifests/cluster.yaml
+++ b/integration/cluster-manifests/cluster.yaml
@@ -47,7 +47,7 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: AWSMachineTemplate
       name: test-ci-cluster-control-plane
-  replicas: 1
+  replicas: 3
   upgradeStrategy: SmartUpgrade
   version: v1.27.0
 ---


### PR DESCRIPTION
This prevents situations where the join fails indefinitely and we can not see anything in the logs.
Also changed the number of control plane replicas in default `cluster.yaml` manifest for e2e tests since we're testing rolling upgrades with that manifest.