### PR TITLE
fix: bump kustomize version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2 )
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest


### PR DESCRIPTION
Addresses [this issue](https://github.com/kubernetes-sigs/kustomize/issues/3618), which makes the `make install` fail