### PR TITLE
update openstack provider resources to v1beta1

### DIFF
--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -8,6 +8,7 @@ export OPENSTACK_CLOUD=openstack
 export OPENSTACK_CLOUD_CONFIG_SECRET_NAME=cloud-config
 
 # OpenStack region and network configuration. External network ID is only needed if multiple external networks exist.
+export OPENSTACK_DISABLE_EXTERNAL_NETWORK=false
 export OPENSTACK_EXTERNAL_NETWORK_ID=""
 export OPENSTACK_FAILURE_DOMAIN="nova"
 

--- a/templates/cluster-template-openstack.rc
+++ b/templates/cluster-template-openstack.rc
@@ -8,7 +8,6 @@ export OPENSTACK_CLOUD=openstack
 export OPENSTACK_CLOUD_CONFIG_SECRET_NAME=cloud-config
 
 # OpenStack region and network configuration. External network ID is only needed if multiple external networks exist.
-export OPENSTACK_DISABLE_EXTERNAL_NETWORK=false
 export OPENSTACK_EXTERNAL_NETWORK_ID=""
 export OPENSTACK_FAILURE_DOMAIN="nova"
 

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -28,7 +28,7 @@ spec:
   managedSubnets:
   - cidr: ${OPENSTACK_NETWORK_CIDR}
     dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
-  disableExternalNetwork: ${OPENSTACK_DISABLE_EXTERNAL_NETWORK:=false}
+  disableExternalNetwork: false
   externalNetwork:
     id: ${OPENSTACK_EXTERNAL_NETWORK_ID:=""}
 ---

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -21,9 +21,9 @@ metadata:
 spec:
   apiServerLoadBalancer:
     enabled: ${OPENSTACK_USE_OCTAVIA_LOADBALANCER}
-  cloudName: ${OPENSTACK_CLOUD}
   identityRef:
     name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
+    cloudName: ${OPENSTACK_CLOUD}
   nodeCidr: ${OPENSTACK_NETWORK_CIDR}
   disablePortSecurity: true
   dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
@@ -66,9 +66,9 @@ spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
-      cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
+        cloudName: ${OPENSTACK_CLOUD}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -101,9 +101,9 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
+        cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -14,7 +14,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -24,10 +24,13 @@ spec:
   identityRef:
     name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
     cloudName: ${OPENSTACK_CLOUD}
-  nodeCidr: ${OPENSTACK_NETWORK_CIDR}
   disablePortSecurity: true
-  dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
-  externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID:=""}
+  managedSubnets:
+  - cidr: ${OPENSTACK_NETWORK_CIDR}
+    dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
+  disableExternalNetwork: ${OPENSTACK_DISABLE_EXTERNAL_NETWORK:=false}
+  externalNetwork:
+    id: ${OPENSTACK_EXTERNAL_NETWORK_ID:=""}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: MicroK8sControlPlane
@@ -49,14 +52,14 @@ spec:
       portCompatibilityRemap: true
   machineTemplate:
     infrastructureTemplate:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: "v${KUBERNETES_VERSION}"
   upgradeStrategy: "${UPGRADE_STRATEGY}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -64,7 +67,9 @@ spec:
   template:
     spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
-      image: ${OPENSTACK_IMAGE_NAME}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
       identityRef:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
@@ -91,10 +96,10 @@ spec:
           kind: MicroK8sConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -105,7 +110,9 @@ spec:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
         cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
-      image: ${OPENSTACK_IMAGE_NAME}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-openstack.yaml
+++ b/templates/cluster-template-openstack.yaml
@@ -24,7 +24,6 @@ spec:
   cloudName: ${OPENSTACK_CLOUD}
   identityRef:
     name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
-    kind: Secret
   nodeCidr: ${OPENSTACK_NETWORK_CIDR}
   disablePortSecurity: true
   dnsNameservers: [${OPENSTACK_DNS_NAMESERVERS:= }]
@@ -70,7 +69,6 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
-        kind: Secret
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -106,7 +104,6 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${OPENSTACK_CLOUD_CONFIG_SECRET_NAME}
-        kind: Secret
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}


### PR DESCRIPTION
Changes the openstack provider API to [`v1beta1`](https://cluster-api-openstack.sigs.k8s.io/topics/crd-changes/v1alpha7-to-v1beta1#openstackmachine)

- The identityRef.Kind field has been removed. It was used to specify the kind of the identity provider to use but was actually ignored. The referenced resource must always be a Secret.
- The cloudName field has been removed from both OpenStackMachine and OpenStackCluster and added to identityRef. It is now a required field when identityRef is specified.
- In v1beta1, OpenStackCluster.Spec.ManagedSubnets array field is introduced. The NodeCIDR and DNSNameservers fields of OpenStackCluster.Spec are moved into that structure (renaming NodeCIDR to CIDR)
- The field externalNetworkID has been renamed to externalNetwork and is now a NetworkParam object rather than a string ID.
- It is now possible for a user to specify that no external network should be used by setting DisableExternalNetwork to true