### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@046337b42822b7868ad62970988929c79f9c1d40 # v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.21"
 
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Check out Code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.21"
 
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Check out Code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Retrieve build information
         id: build
         run: |
@@ -21,7 +21,7 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           sed -i "s,docker.io/cdkbot/capi-bootstrap-provider-microk8s:latest,docker.io/cdkbot/capi-bootstrap-provider-microk8s:${VERSION//v}," bootstrap-components.yaml
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@6232f0b438cb856c39d14f8743e3a7c99fc879af # v0.1.14
         with:
           name: 'Release ${{ env.VERSION }}'
           files: |


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.

## Changes

- Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs
- Preserved original tag/branch versions in inline comments for readability
- Left already-pinned actions unchanged

## Testing

- Verified all `uses:` references in `.github/workflows/` now use immutable SHAs